### PR TITLE
[codex] Add quality checks workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,39 @@
+name: Quality Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test --workspace
+
+      - name: Check AGENTS.md index
+        run: cargo xtask agents-md-index check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,11 @@ Check whether the embedded project index is current with `cargo xtask agents-md-
 [Project Index]|root:.
 |IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning for repository-specific behavior, structure, and APIs.
 |exclude_dirs:{.git,.next,.mypy_cache,.pytest_cache,.venv,.workpad,__pycache__,build,coverage,dist,node_modules,target,venv}
-|exclude_files:{.env,.env.*,*.key,*.p12,*.pem,*.pfx,id_ed25519*,id_rsa*}
+|exclude_files:{.git,.env,.env.*,*.key,*.p12,*.pem,*.pfx,id_ed25519*,id_rsa*}
 |.:{.cargo/,.github/,.gitignore,.pre-commit-config.yaml,AGENTS.md,Cargo.lock,Cargo.toml,README.md,crates/,dist-workspace.toml,rust-toolchain.toml,xtask/}
 |.cargo:{config.toml}
 |.github:{workflows/}
-|.github/workflows:{release.yml}
+|.github/workflows:{quality.yml,release.yml}
 |crates:{memoryroam-cli/,memoryroam-domain/,memoryroam-read/,memoryroam-storage-sqlite/,memoryroam-write/}
 |crates/memoryroam-cli:{Cargo.toml,README.md,src/,tests/}
 |crates/memoryroam-cli/src:{main.rs}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,9 @@ dependencies = [
 [[package]]
 name = "xtask"
 version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "zmij"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 dist = false
 
 [dependencies]
+
+[dev-dependencies]
+tempfile = "3.23.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,6 +25,7 @@ const EXCLUDE_DIRS: &[&str] = &[
     "venv",
 ];
 const EXCLUDE_FILES: &[&str] = &[
+    ".git",
     ".env",
     ".env.*",
     "*.key",
@@ -243,5 +244,33 @@ fn upsert_index_block(current: &str, rendered_block: &str) -> Result<String, Str
         _ => Err(String::from(
             "AGENTS.md index markers must appear at most once each",
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_directory_entries;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn collect_directory_entries_excludes_git_file_in_worktree_layout() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let root = temp_dir.path();
+
+        fs::write(root.join(".git"), "gitdir: /tmp/worktree")
+            .expect("worktree git file should be created");
+        fs::write(root.join("AGENTS.md"), "index").expect("agents file should be created");
+
+        let mut entries = BTreeMap::new();
+        collect_directory_entries(root, ".", &mut entries)
+            .expect("directory collection should succeed");
+
+        let root_entries = entries.get(".").expect("root entry should exist");
+        assert!(
+            !root_entries.iter().any(|entry| entry == ".git"),
+            "worktree .git file should be excluded from the project index",
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a dedicated GitHub Actions workflow to run the repository's existing quality checks on pull requests and pushes to `main`.

It also fixes the `xtask agents-md-index` generator so worktree checkouts do not incorrectly include the `.git` file in the embedded project index, and adds a regression test for that case.

## Why

Issue #3 identified that the repository already defines concrete validation commands locally, but did not have a daily CI workflow to execute them automatically for integration work.

While implementing that workflow, the AGENTS index generator was found to behave incorrectly in git worktrees. Without fixing that behavior, the new AGENTS index check could fail for worktree-based development even when repository content was otherwise correct.

## Validation

The following checks were run locally:

- `pre-commit run --all-files`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo xtask agents-md-index check`
- `codex-review-final main`
