### PR TITLE
[codex] Add bootstrap script for Ubuntu development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Check whether the embedded project index is current with `cargo xtask agents-md-
 |IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning for repository-specific behavior, structure, and APIs.
 |exclude_dirs:{**/.workpad/,**/target/}
 |exclude_files:{}
-|.:{.cargo/,.github/,.gitignore,.pre-commit-config.yaml,AGENTS.md,Cargo.lock,Cargo.toml,README.md,crates/,dist-workspace.toml,rust-toolchain.toml,xtask/}
+|.:{.cargo/,.github/,.gitignore,.pre-commit-config.yaml,AGENTS.md,Cargo.lock,Cargo.toml,README.md,crates/,dist-workspace.toml,rust-toolchain.toml,scripts/,xtask/}
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{quality.yml,release.yml}
@@ -44,6 +44,7 @@ Check whether the embedded project index is current with `cargo xtask agents-md-
 |crates/memoryroam-storage-sqlite/src:{lib.rs}
 |crates/memoryroam-write:{Cargo.toml,README.md,src/}
 |crates/memoryroam-write/src:{lib.rs}
+|scripts:{bootstrap.sh}
 |xtask:{Cargo.toml,src/}
 |xtask/src:{main.rs}
 ```

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -29,9 +29,9 @@ ensure_git_repository_root() {
   cd "$repository_root"
 }
 
-ensure_python_pip() {
-  if ! python3 -m pip --version >/dev/null 2>&1; then
-    fail "python3 -m pip is required"
+ensure_python_venv() {
+  if ! python3 -m venv --help >/dev/null 2>&1; then
+    fail "python3 venv support is required"
   fi
 }
 
@@ -54,17 +54,22 @@ install_rustup_if_missing() {
 install_rust_toolchain() {
   log "Installing Rust toolchain and required components"
   rustup toolchain install stable --profile minimal --component clippy --component rustfmt
-  rustup default stable
 }
 
 install_pre_commit() {
-  log "Installing pre-commit"
-  python3 -m pip install --user pre-commit
+  local virtualenv_dir=".workpad/bootstrap-venv"
+
+  log "Installing pre-commit into $virtualenv_dir"
+  mkdir -p .workpad
+  python3 -m venv "$virtualenv_dir"
+  "$virtualenv_dir/bin/python" -m pip install pre-commit
 }
 
 install_git_hooks() {
+  local virtualenv_dir=".workpad/bootstrap-venv"
+
   log "Installing repository hooks"
-  python3 -m pre_commit install --install-hooks
+  "$virtualenv_dir/bin/python" -m pre_commit install --install-hooks
 }
 
 configure_repository_git_settings() {
@@ -83,7 +88,7 @@ main() {
   require_command git
   require_command curl
   require_command python3
-  ensure_python_pip
+  ensure_python_venv
 
   ensure_git_repository_root
   install_rustup_if_missing

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -79,6 +79,12 @@ load_cargo_environment() {
   fi
 }
 
+ensure_cargo_bin_on_path() {
+  if [[ -d "$HOME/.cargo/bin" ]]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+  fi
+}
+
 install_rustup_if_missing() {
   if command -v rustup >/dev/null 2>&1; then
     return
@@ -125,6 +131,7 @@ main() {
 
   load_cargo_environment
   install_rustup_if_missing
+  ensure_cargo_bin_on_path
   load_cargo_environment
 
   require_command rustup

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -74,6 +74,11 @@ install_rustup_if_missing() {
     return
   fi
 
+  if [[ -x "$HOME/.cargo/bin/rustup" ]]; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+    return
+  fi
+
   log "Installing rustup"
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 }
@@ -91,7 +96,9 @@ install_pre_commit() {
   local wrapper_path
 
   existing_pre_commit="$(command -v pre-commit || true)"
-  if [[ -n "$existing_pre_commit" ]] && "$existing_pre_commit" --version >/dev/null 2>&1; then
+  if [[ -n "$existing_pre_commit" ]] \
+    && "$existing_pre_commit" --version >/dev/null 2>&1 \
+    && [[ -z "${VIRTUAL_ENV:-}" || "$existing_pre_commit" != "$VIRTUAL_ENV/"* ]]; then
     PRE_COMMIT_COMMAND="$existing_pre_commit"
     log "Using existing pre-commit at $PRE_COMMIT_COMMAND"
     return
@@ -143,6 +150,7 @@ main() {
   require_command python3
 
   ensure_git_repository_root
+  load_cargo_environment
   install_rustup_if_missing
   load_cargo_environment
   require_command rustup

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -53,7 +53,7 @@ apt_get() {
   fi
 
   require_command sudo
-  DEBIAN_FRONTEND=noninteractive sudo -n apt-get "$@"
+  DEBIAN_FRONTEND=noninteractive sudo apt-get "$@"
 }
 
 install_system_packages() {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -38,7 +38,7 @@ ensure_python_venv() {
 }
 
 user_bin_dir() {
-  python3 -m site --user-base
+  python3 -c 'import site; print(site.getuserbase())'
 }
 
 ensure_user_bin_on_path() {
@@ -97,6 +97,7 @@ install_pre_commit() {
   fi
 
   shared_virtualenv_dir="$(git_common_dir)/bootstrap-pre-commit-venv"
+  ensure_user_bin_on_path
   user_base="$(user_bin_dir)"
   wrapper_path="$user_base/bin/pre-commit"
 
@@ -134,7 +135,6 @@ main() {
   require_command curl
   require_command python3
   ensure_python_venv
-  ensure_user_bin_on_path
 
   ensure_git_repository_root
   install_rustup_if_missing

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -19,6 +19,12 @@ require_command() {
   fi
 }
 
+ensure_non_root_user() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    fail "run this script as a normal user, not as root"
+  fi
+}
+
 ensure_repository_root() {
   local repository_root
 
@@ -116,6 +122,7 @@ prefetch_cargo_dependencies() {
 
 main() {
   require_command git
+  ensure_non_root_user
 
   ensure_repository_root
   ensure_ubuntu_2404

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+PRE_COMMIT_COMMAND=""
+
 log() {
   printf '==> %s\n' "$1"
 }
@@ -35,6 +37,31 @@ ensure_python_venv() {
   fi
 }
 
+user_bin_dir() {
+  python3 -m site --user-base
+}
+
+ensure_user_bin_on_path() {
+  local user_base
+
+  user_base="$(user_bin_dir)"
+
+  case ":$PATH:" in
+    *":$user_base/bin:"*) ;;
+    *) fail "$user_base/bin must be on PATH" ;;
+  esac
+}
+
+git_common_dir() {
+  local common_dir
+
+  common_dir="$(git rev-parse --git-common-dir)"
+  (
+    cd "$common_dir"
+    pwd
+  )
+}
+
 load_cargo_environment() {
   if [[ -f "$HOME/.cargo/env" ]]; then
     # shellcheck disable=SC1090
@@ -57,19 +84,37 @@ install_rust_toolchain() {
 }
 
 install_pre_commit() {
-  local virtualenv_dir=".workpad/bootstrap-venv"
+  local existing_pre_commit
+  local shared_virtualenv_dir
+  local user_base
+  local wrapper_path
 
-  log "Installing pre-commit into $virtualenv_dir"
-  mkdir -p .workpad
-  python3 -m venv "$virtualenv_dir"
-  "$virtualenv_dir/bin/python" -m pip install pre-commit
+  existing_pre_commit="$(command -v pre-commit || true)"
+  if [[ -n "$existing_pre_commit" ]]; then
+    PRE_COMMIT_COMMAND="$existing_pre_commit"
+    log "Using existing pre-commit at $PRE_COMMIT_COMMAND"
+    return
+  fi
+
+  shared_virtualenv_dir="$(git_common_dir)/bootstrap-pre-commit-venv"
+  user_base="$(user_bin_dir)"
+  wrapper_path="$user_base/bin/pre-commit"
+
+  log "Installing pre-commit into $shared_virtualenv_dir"
+  mkdir -p "$user_base/bin"
+  python3 -m venv "$shared_virtualenv_dir"
+  "$shared_virtualenv_dir/bin/python" -m pip install pre-commit
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "exec \"$shared_virtualenv_dir/bin/pre-commit\" \"\$@\"" \
+    > "$wrapper_path"
+  chmod +x "$wrapper_path"
+  PRE_COMMIT_COMMAND="$wrapper_path"
 }
 
 install_git_hooks() {
-  local virtualenv_dir=".workpad/bootstrap-venv"
-
   log "Installing repository hooks"
-  "$virtualenv_dir/bin/python" -m pre_commit install --install-hooks
+  "$PRE_COMMIT_COMMAND" install --install-hooks
 }
 
 configure_repository_git_settings() {
@@ -89,6 +134,7 @@ main() {
   require_command curl
   require_command python3
   ensure_python_venv
+  ensure_user_bin_on_path
 
   ensure_git_repository_root
   install_rustup_if_missing

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  printf '==> %s\n' "$1"
+}
+
+fail() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    fail "required command not found: $command_name"
+  fi
+}
+
+ensure_git_repository_root() {
+  local repository_root
+
+  if ! repository_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    fail "run this script from inside the repository worktree"
+  fi
+
+  cd "$repository_root"
+}
+
+ensure_python_pip() {
+  if ! python3 -m pip --version >/dev/null 2>&1; then
+    fail "python3 -m pip is required"
+  fi
+}
+
+load_cargo_environment() {
+  if [[ -f "$HOME/.cargo/env" ]]; then
+    # shellcheck disable=SC1090
+    . "$HOME/.cargo/env"
+  fi
+}
+
+install_rustup_if_missing() {
+  if command -v rustup >/dev/null 2>&1; then
+    return
+  fi
+
+  log "Installing rustup"
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+}
+
+install_rust_toolchain() {
+  log "Installing Rust toolchain and required components"
+  rustup toolchain install stable --profile minimal --component clippy --component rustfmt
+  rustup default stable
+}
+
+install_pre_commit() {
+  log "Installing pre-commit"
+  python3 -m pip install --user pre-commit
+}
+
+install_git_hooks() {
+  log "Installing repository hooks"
+  python3 -m pre_commit install --install-hooks
+}
+
+configure_repository_git_settings() {
+  log "Configuring repository-local Git settings"
+  git config --local pull.rebase true
+  git config --local branch.autoSetupRebase always
+  git config --local merge.ff only
+}
+
+prefetch_cargo_dependencies() {
+  log "Fetching workspace Cargo dependencies"
+  cargo fetch --locked
+}
+
+main() {
+  require_command git
+  require_command curl
+  require_command python3
+  ensure_python_pip
+
+  ensure_git_repository_root
+  install_rustup_if_missing
+  load_cargo_environment
+  require_command rustup
+  require_command cargo
+
+  install_rust_toolchain
+  install_pre_commit
+  install_git_hooks
+  configure_repository_git_settings
+  prefetch_cargo_dependencies
+
+  log "Bootstrap complete"
+}
+
+main "$@"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -13,6 +13,10 @@ fail() {
   exit 1
 }
 
+warn() {
+  printf 'warning: %s\n' "$1" >&2
+}
+
 require_command() {
   local command_name="$1"
 
@@ -34,6 +38,7 @@ ensure_git_repository_root() {
 ensure_python_venv() {
   local probe_dir
 
+  require_command mktemp
   probe_dir="$(mktemp -d)"
   if ! python3 -m venv "$probe_dir/venv" >/dev/null 2>&1; then
     rm -rf "$probe_dir"
@@ -45,6 +50,16 @@ ensure_python_venv() {
 
 user_bin_dir() {
   python3 -c 'import site; print(site.getuserbase())'
+}
+
+user_bin_on_path() {
+  local user_bin
+
+  user_bin="$(user_bin_dir)/bin"
+  case ":$PATH:" in
+    *":$user_bin:"*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 load_cargo_environment() {
@@ -82,6 +97,7 @@ install_pre_commit() {
     return
   fi
 
+  ensure_python_venv
   shared_install_root="${XDG_DATA_HOME:-$HOME/.local/share}/memoryroam-cli"
   shared_virtualenv_dir="$shared_install_root/pre-commit-venv"
   user_bin="$(user_bin_dir)/bin"
@@ -98,6 +114,10 @@ install_pre_commit() {
     > "$wrapper_path"
   chmod +x "$wrapper_path"
   PRE_COMMIT_COMMAND="$shared_virtualenv_dir/bin/pre-commit"
+
+  if ! user_bin_on_path; then
+    warn "pre-commit was installed to $wrapper_path, but $user_bin is not on PATH in this shell"
+  fi
 }
 
 install_git_hooks() {
@@ -121,8 +141,6 @@ main() {
   require_command git
   require_command curl
   require_command python3
-  require_command mktemp
-  ensure_python_venv
 
   ensure_git_repository_root
   install_rustup_if_missing

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -32,9 +32,19 @@ ensure_git_repository_root() {
 }
 
 ensure_python_venv() {
-  if ! python3 -m venv --help >/dev/null 2>&1; then
+  local probe_dir
+
+  probe_dir="$(mktemp -d)"
+  if ! python3 -m venv "$probe_dir/venv" >/dev/null 2>&1; then
+    rm -rf "$probe_dir"
     fail "python3 venv support is required"
   fi
+
+  rm -rf "$probe_dir"
+}
+
+user_bin_dir() {
+  python3 -c 'import site; print(site.getuserbase())'
 }
 
 load_cargo_environment() {
@@ -62,6 +72,7 @@ install_pre_commit() {
   local existing_pre_commit
   local shared_install_root
   local shared_virtualenv_dir
+  local user_bin
   local wrapper_path
 
   existing_pre_commit="$(command -v pre-commit || true)"
@@ -73,15 +84,12 @@ install_pre_commit() {
 
   shared_install_root="${XDG_DATA_HOME:-$HOME/.local/share}/memoryroam-cli"
   shared_virtualenv_dir="$shared_install_root/pre-commit-venv"
-
-  if [[ -n "$existing_pre_commit" ]]; then
-    wrapper_path="$existing_pre_commit"
-  else
-    wrapper_path="$(dirname "$(command -v cargo)")/pre-commit"
-  fi
+  user_bin="$(user_bin_dir)/bin"
+  wrapper_path="$user_bin/pre-commit"
 
   log "Installing pre-commit into $shared_virtualenv_dir"
   mkdir -p "$shared_install_root"
+  mkdir -p "$user_bin"
   python3 -m venv "$shared_virtualenv_dir"
   "$shared_virtualenv_dir/bin/python" -m pip install pre-commit
   printf '%s\n' \
@@ -89,7 +97,7 @@ install_pre_commit() {
     "exec \"$shared_virtualenv_dir/bin/pre-commit\" \"\$@\"" \
     > "$wrapper_path"
   chmod +x "$wrapper_path"
-  PRE_COMMIT_COMMAND="$wrapper_path"
+  PRE_COMMIT_COMMAND="$shared_virtualenv_dir/bin/pre-commit"
 }
 
 install_git_hooks() {
@@ -113,6 +121,7 @@ main() {
   require_command git
   require_command curl
   require_command python3
+  require_command mktemp
   ensure_python_venv
 
   ensure_git_repository_root

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-PRE_COMMIT_COMMAND=""
-
 log() {
   printf '==> %s\n' "$1"
 }
@@ -11,10 +9,6 @@ log() {
 fail() {
   printf 'error: %s\n' "$1" >&2
   exit 1
-}
-
-warn() {
-  printf 'warning: %s\n' "$1" >&2
 }
 
 require_command() {
@@ -25,7 +19,7 @@ require_command() {
   fi
 }
 
-ensure_git_repository_root() {
+ensure_repository_root() {
   local repository_root
 
   if ! repository_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
@@ -35,33 +29,46 @@ ensure_git_repository_root() {
   cd "$repository_root"
 }
 
-ensure_python_venv() {
-  local probe_dir
-
-  require_command python3
-  require_command mktemp
-  probe_dir="$(mktemp -d)"
-  if ! python3 -m venv "$probe_dir/venv" >/dev/null 2>&1; then
-    rm -rf "$probe_dir"
-    fail "python3 venv support is required"
+ensure_ubuntu_2404() {
+  if [[ ! -r /etc/os-release ]]; then
+    fail "unable to read /etc/os-release"
   fi
 
-  rm -rf "$probe_dir"
+  # shellcheck disable=SC1091
+  . /etc/os-release
+
+  if [[ "${ID:-}" != "ubuntu" ]]; then
+    fail "this script only supports Ubuntu 24.04"
+  fi
+
+  if [[ "${VERSION_ID:-}" != "24.04" ]]; then
+    fail "this script only supports Ubuntu 24.04"
+  fi
 }
 
-user_bin_dir() {
-  require_command python3
-  python3 -c 'import site; print(site.getuserbase())'
+apt_get() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    DEBIAN_FRONTEND=noninteractive apt-get "$@"
+    return
+  fi
+
+  require_command sudo
+  DEBIAN_FRONTEND=noninteractive sudo -n apt-get "$@"
 }
 
-user_bin_on_path() {
-  local user_bin
-
-  user_bin="$(user_bin_dir)/bin"
-  case ":$PATH:" in
-    *":$user_bin:"*) return 0 ;;
-    *) return 1 ;;
-  esac
+install_system_packages() {
+  log "Installing Ubuntu development packages"
+  apt_get update
+  apt_get install -y \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    pkg-config \
+    pre-commit \
+    python3 \
+    python3-pip \
+    python3-venv
 }
 
 load_cargo_environment() {
@@ -81,58 +88,18 @@ install_rustup_if_missing() {
     return
   fi
 
-  require_command curl
   log "Installing rustup"
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 }
 
 install_rust_toolchain() {
-  log "Installing Rust toolchain and required components"
+  log "Installing Rust toolchain"
   rustup toolchain install stable --profile minimal --component clippy --component rustfmt
 }
 
-install_pre_commit() {
-  local existing_pre_commit
-  local shared_install_root
-  local shared_virtualenv_dir
-  local user_bin
-  local wrapper_path
-
-  existing_pre_commit="$(command -v pre-commit || true)"
-  if [[ -n "$existing_pre_commit" ]] \
-    && "$existing_pre_commit" --version >/dev/null 2>&1 \
-    && [[ -z "${VIRTUAL_ENV:-}" || "$existing_pre_commit" != "$VIRTUAL_ENV/"* ]]; then
-    PRE_COMMIT_COMMAND="$existing_pre_commit"
-    log "Using existing pre-commit at $PRE_COMMIT_COMMAND"
-    return
-  fi
-
-  ensure_python_venv
-  shared_install_root="${XDG_DATA_HOME:-$HOME/.local/share}/memoryroam-cli"
-  shared_virtualenv_dir="$shared_install_root/pre-commit-venv"
-  user_bin="$(user_bin_dir)/bin"
-  wrapper_path="$user_bin/pre-commit"
-
-  log "Installing pre-commit into $shared_virtualenv_dir"
-  mkdir -p "$shared_install_root"
-  mkdir -p "$user_bin"
-  python3 -m venv "$shared_virtualenv_dir"
-  "$shared_virtualenv_dir/bin/python" -m pip install pre-commit
-  printf '%s\n' \
-    '#!/usr/bin/env bash' \
-    "exec \"$shared_virtualenv_dir/bin/pre-commit\" \"\$@\"" \
-    > "$wrapper_path"
-  chmod +x "$wrapper_path"
-  PRE_COMMIT_COMMAND="$shared_virtualenv_dir/bin/pre-commit"
-
-  if ! user_bin_on_path; then
-    warn "pre-commit was installed to $wrapper_path, but $user_bin is not on PATH in this shell"
-  fi
-}
-
 install_git_hooks() {
-  log "Installing repository hooks"
-  "$PRE_COMMIT_COMMAND" install --install-hooks
+  log "Installing pre-commit hooks"
+  pre-commit install --install-hooks
 }
 
 configure_repository_git_settings() {
@@ -150,15 +117,19 @@ prefetch_cargo_dependencies() {
 main() {
   require_command git
 
-  ensure_git_repository_root
+  ensure_repository_root
+  ensure_ubuntu_2404
+  install_system_packages
+
   load_cargo_environment
   install_rustup_if_missing
   load_cargo_environment
+
   require_command rustup
   require_command cargo
+  require_command pre-commit
 
   install_rust_toolchain
-  install_pre_commit
   install_git_hooks
   configure_repository_git_settings
   prefetch_cargo_dependencies

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -53,13 +53,8 @@ ensure_ubuntu_2404() {
 }
 
 apt_get() {
-  if [[ "${EUID}" -eq 0 ]]; then
-    DEBIAN_FRONTEND=noninteractive apt-get "$@"
-    return
-  fi
-
   require_command sudo
-  DEBIAN_FRONTEND=noninteractive sudo apt-get "$@"
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get "$@"
 }
 
 install_system_packages() {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -37,31 +37,6 @@ ensure_python_venv() {
   fi
 }
 
-user_bin_dir() {
-  python3 -c 'import site; print(site.getuserbase())'
-}
-
-ensure_user_bin_on_path() {
-  local user_base
-
-  user_base="$(user_bin_dir)"
-
-  case ":$PATH:" in
-    *":$user_base/bin:"*) ;;
-    *) fail "$user_base/bin must be on PATH" ;;
-  esac
-}
-
-git_common_dir() {
-  local common_dir
-
-  common_dir="$(git rev-parse --git-common-dir)"
-  (
-    cd "$common_dir"
-    pwd
-  )
-}
-
 load_cargo_environment() {
   if [[ -f "$HOME/.cargo/env" ]]; then
     # shellcheck disable=SC1090
@@ -85,24 +60,28 @@ install_rust_toolchain() {
 
 install_pre_commit() {
   local existing_pre_commit
+  local shared_install_root
   local shared_virtualenv_dir
-  local user_base
   local wrapper_path
 
   existing_pre_commit="$(command -v pre-commit || true)"
-  if [[ -n "$existing_pre_commit" ]]; then
+  if [[ -n "$existing_pre_commit" ]] && "$existing_pre_commit" --version >/dev/null 2>&1; then
     PRE_COMMIT_COMMAND="$existing_pre_commit"
     log "Using existing pre-commit at $PRE_COMMIT_COMMAND"
     return
   fi
 
-  shared_virtualenv_dir="$(git_common_dir)/bootstrap-pre-commit-venv"
-  ensure_user_bin_on_path
-  user_base="$(user_bin_dir)"
-  wrapper_path="$user_base/bin/pre-commit"
+  shared_install_root="${XDG_DATA_HOME:-$HOME/.local/share}/memoryroam-cli"
+  shared_virtualenv_dir="$shared_install_root/pre-commit-venv"
+
+  if [[ -n "$existing_pre_commit" ]]; then
+    wrapper_path="$existing_pre_commit"
+  else
+    wrapper_path="$(dirname "$(command -v cargo)")/pre-commit"
+  fi
 
   log "Installing pre-commit into $shared_virtualenv_dir"
-  mkdir -p "$user_base/bin"
+  mkdir -p "$shared_install_root"
   python3 -m venv "$shared_virtualenv_dir"
   "$shared_virtualenv_dir/bin/python" -m pip install pre-commit
   printf '%s\n' \

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -38,6 +38,7 @@ ensure_git_repository_root() {
 ensure_python_venv() {
   local probe_dir
 
+  require_command python3
   require_command mktemp
   probe_dir="$(mktemp -d)"
   if ! python3 -m venv "$probe_dir/venv" >/dev/null 2>&1; then
@@ -49,6 +50,7 @@ ensure_python_venv() {
 }
 
 user_bin_dir() {
+  require_command python3
   python3 -c 'import site; print(site.getuserbase())'
 }
 
@@ -79,6 +81,7 @@ install_rustup_if_missing() {
     return
   fi
 
+  require_command curl
   log "Installing rustup"
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 }
@@ -146,8 +149,6 @@ prefetch_cargo_dependencies() {
 
 main() {
   require_command git
-  require_command curl
-  require_command python3
 
   ensure_git_repository_root
   load_cargo_environment

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -136,10 +136,13 @@ main() {
   load_cargo_environment
 
   require_command rustup
-  require_command cargo
-  require_command pre-commit
 
   install_rust_toolchain
+  ensure_cargo_bin_on_path
+  load_cargo_environment
+
+  require_command cargo
+  require_command pre-commit
   install_git_hooks
   configure_repository_git_settings
   prefetch_cargo_dependencies

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -35,7 +35,7 @@ ensure_repository_root() {
   cd "$repository_root"
 }
 
-ensure_ubuntu_2404() {
+ensure_supported_ubuntu() {
   if [[ ! -r /etc/os-release ]]; then
     fail "unable to read /etc/os-release"
   fi
@@ -44,12 +44,13 @@ ensure_ubuntu_2404() {
   . /etc/os-release
 
   if [[ "${ID:-}" != "ubuntu" ]]; then
-    fail "this script only supports Ubuntu 24.04"
+    fail "this script only supports Ubuntu"
   fi
 
-  if [[ "${VERSION_ID:-}" != "24.04" ]]; then
-    fail "this script only supports Ubuntu 24.04"
-  fi
+  case "${VERSION_ID:-}" in
+    22.04 | 24.04) ;;
+    *) fail "this script only supports Ubuntu 22.04 and 24.04" ;;
+  esac
 }
 
 apt_get() {
@@ -126,7 +127,7 @@ main() {
   ensure_non_root_user
 
   ensure_repository_root
-  ensure_ubuntu_2404
+  ensure_supported_ubuntu
   install_system_packages
 
   load_cargo_environment


### PR DESCRIPTION
## Summary
- add `scripts/bootstrap.sh` as a one-command bootstrap entrypoint for Ubuntu developer environments
- install the required system packages, Rust toolchain components, and `pre-commit`, then configure repository-local Git settings
- prefetch workspace Cargo dependencies with `cargo fetch --locked` and update the embedded AGENTS index for the new `scripts/` directory

Closes #4

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo xtask agents-md-index check`
- `git rebase origin/main`
