### PR TITLE
[codex] Redesign CLI around daily notes and root workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,9 @@ Check whether the embedded project index is current with `cargo xtask agents-md-
 |.cargo:{config.toml}
 |.github:{workflows/}
 |.github/workflows:{quality.yml,release.yml}
-|crates:{memoryroam-cli/,memoryroam-domain/,memoryroam-read/,memoryroam-storage-sqlite/,memoryroam-write/}
+|crates:{memoryroam-application/,memoryroam-cli/,memoryroam-domain/,memoryroam-read/,memoryroam-storage-sqlite/,memoryroam-write/}
+|crates/memoryroam-application:{Cargo.toml,README.md,src/}
+|crates/memoryroam-application/src:{lib.rs}
 |crates/memoryroam-cli:{Cargo.toml,README.md,src/,tests/}
 |crates/memoryroam-cli/src:{main.rs}
 |crates/memoryroam-cli/tests:{cli.rs}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +135,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -166,6 +192,12 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "difflib"
@@ -272,6 +304,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +356,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -343,13 +409,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoryroam-application"
+version = "0.1.0"
+dependencies = [
+ "memoryroam-domain",
+ "memoryroam-read",
+ "memoryroam-write",
+]
+
+[[package]]
 name = "memoryroam-cli"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "chrono",
  "clap",
+ "memoryroam-application",
  "memoryroam-domain",
- "memoryroam-read",
  "memoryroam-storage-sqlite",
  "memoryroam-write",
  "predicates",
@@ -542,6 +618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +791,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,10 +870,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,9 @@ version = "0.1.0"
 dependencies = [
  "memoryroam-domain",
  "memoryroam-read",
+ "memoryroam-storage-sqlite",
  "memoryroam-write",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "memoryroam-application"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "memoryroam-domain",
  "memoryroam-read",
  "memoryroam-storage-sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/memoryroam-application",
     "crates/memoryroam-cli",
     "crates/memoryroam-domain",
     "crates/memoryroam-read",

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ cargo build --bin memoryroam
 
 ## Workspace Layout
 
+- `crates/memoryroam-application`: unified user-facing workflows shared by the CLI.
 - `crates/memoryroam-cli`: command-line entrypoint and text output.
 - `crates/memoryroam-domain`: core types, parsing, canonicalization, rendering, and repository contracts.
 - `crates/memoryroam-read`: read-only use cases and rendered read models.
@@ -68,96 +69,58 @@ If the file does not exist, the command fails instead of silently creating an em
 
 ## Common Tasks
 
-Create a top-level node:
+Capture a note into today's daily note:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 create --content "Software engineering"
+cargo run --bin memoryroam -- --db notes.sqlite3 note "Design issue 7 interactions"
 ```
 
-Create multiple sibling nodes in one command:
+Open today's daily note:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 create --content $'Topic\nSee {{Topic}}'
+cargo run --bin memoryroam -- --db notes.sqlite3 day
 ```
 
-Add aliases to a node:
+Open a specific daily note:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 alias add --id 1 --text "SWE" --text "engineering"
+cargo run --bin memoryroam -- --db notes.sqlite3 day 2026-04-11
 ```
 
-Read a node with structure context and incoming links:
+Read one node with context markers:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 read --id 1
+cargo run --bin memoryroam -- --db notes.sqlite3 read 42
 ```
 
-List top-level nodes:
+Create or reuse a root node and list matching notes:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 list --top-level
+cargo run --bin memoryroam -- --db notes.sqlite3 root create "Software engineering"
 ```
 
-List direct children of a node:
+Rewrite selected notes to link to one root node:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 list --children-of 1
-```
-
-Update node content from an argument:
-
-```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 update --id 2 --content "See {{1}}"
-```
-
-Update node content from stdin:
-
-```bash
-printf 'Updated note\n' | cargo run --bin memoryroam -- --db notes.sqlite3 update --id 2
-```
-
-Move a node before another node:
-
-```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 move --id 3 --before 1
-```
-
-Move a node under a parent:
-
-```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 move --id 3 --last-child-of 1
-```
-
-Delete a subtree:
-
-```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 delete --id 3 --cascade
-```
-
-Delete a node and reparent its children:
-
-```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 delete --id 3 --after 1
-```
-
-Remove an alias using normalized lookup text:
-
-```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 alias remove --id 1 --text "topic"
+cargo run --bin memoryroam -- --db notes.sqlite3 root apply 12 --node 41 --node 42
 ```
 
 ## Data Rules
 
 - Node content is always a single line.
-- Multi-line `create` input means multiple sibling nodes.
+- `note` creates exactly one node and always appends it under today's daily note.
+- Root nodes and daily note date nodes are both top-level nodes, but top-level nodes never participate in sibling chains.
+- Daily note date nodes are represented by ordinary `nodes` rows whose `content` is `YYYY-MM-DD`.
+- Daily note date nodes are immutable through ordinary write operations.
 - Links are stored in canonical form, using stable node IDs internally.
 - Lookup normalization trims surrounding whitespace and rejects purely numeric or reserved-syntax keys.
 - `read` renders unlabeled links as `{{id::>current target content}}`.
+- Root-link rewrites only replace plain-text matches and do not rewrite existing link tokens.
 - Create and update reject link cycles before they are persisted.
-- Multi-line `create` is atomic: later failures do not leave earlier lines behind.
 
 ## Package Manuals
 
+- [`memoryroam-application`](./crates/memoryroam-application/README.md)
 - [`memoryroam-domain`](./crates/memoryroam-domain/README.md)
 - [`memoryroam-read`](./crates/memoryroam-read/README.md)
 - [`memoryroam-write`](./crates/memoryroam-write/README.md)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,54 @@ All non-`init` commands require an existing database file.
 If the file does not exist, the command fails instead of silently creating an empty database.
 This unreleased branch does not provide schema migration or backward compatibility for older database files.
 
+## Quick Start
+
+Create a database file:
+
+```bash
+memoryroam --db notes.sqlite3 init
+```
+
+Write two notes into today's daily note:
+
+```bash
+memoryroam --db notes.sqlite3 note "Check the scope of issue 7"
+memoryroam --db notes.sqlite3 note "Design the root relink workflow"
+```
+
+Open today's daily note:
+
+```bash
+memoryroam --db notes.sqlite3 day
+```
+
+Read one note with its surrounding context:
+
+```bash
+memoryroam --db notes.sqlite3 read 2
+```
+
+Write two notes that mention one concept:
+
+```bash
+memoryroam --db notes.sqlite3 note "Software engineering is a branch of engineering"
+memoryroam --db notes.sqlite3 note "Software engineering emerged in the 1960s"
+```
+
+Create one root node and list matching notes:
+
+```bash
+memoryroam --db notes.sqlite3 root create "Software engineering"
+```
+
+Rewrite selected notes to link to that root node:
+
+```bash
+memoryroam --db notes.sqlite3 root apply 4 --node 5 --node 6
+```
+
+This workflow assumes a brand-new database, so the sample IDs above are stable in a fresh file.
+
 ## Common Tasks
 
 Capture a note into today's daily note:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Each command starts a fresh process, opens the database file, performs one opera
 ## Install
 
 Published builds are distributed through GitHub Releases.
-The repository does not have a tagged release yet, so the release-based install commands below will start working after the first `vX.Y.Z` release is published.
 
 Install the latest published release on macOS or glibc-based Linux:
 
@@ -24,11 +23,18 @@ If you prefer a manual install, download a platform archive from the [Releases](
 Each archive contains the `memoryroam` executable.
 musl-based Linux distributions such as Alpine are not covered by the current release artifacts.
 
-Until the first tagged release exists, use a source checkout:
+To install a specific release such as `v0.1.0`, replace `latest` with the tag name:
 
 ```bash
-cargo build --bin memoryroam
-./target/debug/memoryroam --help
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/JiaJunDeng5930/MemoryRoamCLI/releases/download/v0.1.0/memoryroam-cli-installer.sh | sh
+```
+
+The installers place `memoryroam` into `CARGO_HOME/bin`.
+If `CARGO_HOME` is not set, the default location is `~/.cargo/bin`.
+Ensure that directory is present in `PATH`, then verify the installation:
+
+```bash
+memoryroam --help
 ```
 
 ## Workspace Layout

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cargo run --bin memoryroam -- --db notes.sqlite3 init
 
 All non-`init` commands require an existing database file.
 If the file does not exist, the command fails instead of silently creating an empty database.
+This unreleased branch does not provide schema migration or backward compatibility for older database files.
 
 ## Common Tasks
 

--- a/crates/memoryroam-application/Cargo.toml
+++ b/crates/memoryroam-application/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 repository = "https://github.com/JiaJunDeng5930/MemoryRoamCLI"
 
 [dependencies]
+chrono = { version = "0.4.44", default-features = false, features = ["std"] }
 memoryroam-domain = { path = "../memoryroam-domain" }
 memoryroam-read = { path = "../memoryroam-read" }
 memoryroam-write = { path = "../memoryroam-write" }

--- a/crates/memoryroam-application/Cargo.toml
+++ b/crates/memoryroam-application/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "memoryroam-application"
+version = "0.1.0"
+edition = "2024"
+description = "User-facing application workflows for MemoryRoam."
+readme = "README.md"
+repository = "https://github.com/JiaJunDeng5930/MemoryRoamCLI"
+
+[dependencies]
+memoryroam-domain = { path = "../memoryroam-domain" }
+memoryroam-read = { path = "../memoryroam-read" }
+memoryroam-write = { path = "../memoryroam-write" }

--- a/crates/memoryroam-application/Cargo.toml
+++ b/crates/memoryroam-application/Cargo.toml
@@ -10,3 +10,7 @@ repository = "https://github.com/JiaJunDeng5930/MemoryRoamCLI"
 memoryroam-domain = { path = "../memoryroam-domain" }
 memoryroam-read = { path = "../memoryroam-read" }
 memoryroam-write = { path = "../memoryroam-write" }
+
+[dev-dependencies]
+memoryroam-storage-sqlite = { path = "../memoryroam-storage-sqlite" }
+tempfile = "3.23.0"

--- a/crates/memoryroam-application/README.md
+++ b/crates/memoryroam-application/README.md
@@ -1,0 +1,3 @@
+# memoryroam-application
+
+`memoryroam-application` exposes the user-facing MemoryRoam workflows used by the CLI.

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -120,7 +120,6 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     ensure_plain_text_root(&content)?;
     ensure_safe_root_label_text(content.as_str())?;
     ensure_referenceable_root_text(&content)?;
-    ensure_root_label_is_available(repository, &content)?;
     let search_text = normalized_root_lookup_text(&content);
     let mut rendered_matches = Vec::new();
     for node in repository.search_text_matches(search_text)? {
@@ -137,6 +136,7 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     let root = match repository.find_root_node_by_content(&content)? {
         Some(node) => node,
         None => {
+            ensure_root_label_is_available(repository, &content)?;
             let node = build_root_node(repository, &content)?;
             match repository.create_root_node(&node) {
                 Ok(node_id) => {
@@ -638,14 +638,13 @@ fn ensure_root_label_is_available<R: ReadRepository>(
 ) -> KernelResult<()> {
     let key = LookupKey::new(content.as_str().to_owned())
         .map_err(|error| KernelError::Input(error.to_string()))?;
-    for candidate in repository.lookup_candidates(&key)? {
-        if !repository.is_root_node(candidate.node_id)? {
-            return Err(KernelError::Constraint(String::from(
-                "root label is already owned by a regular note",
-            )));
-        }
+    if repository.lookup_candidates(&key)?.is_empty() {
+        return Ok(());
     }
-    Ok(())
+
+    Err(KernelError::Constraint(String::from(
+        "root label is already owned by another node",
+    )))
 }
 
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
@@ -686,7 +685,7 @@ mod tests {
         Placement, StoredNode, WriteRepository,
     };
     use memoryroam_storage_sqlite::SqliteStore;
-    use memoryroam_write::init;
+    use memoryroam_write::{add_aliases, init};
     use tempfile::NamedTempFile;
 
     fn store() -> SqliteStore {
@@ -753,6 +752,30 @@ mod tests {
 
         let error = create_root(&mut store, "Topic")
             .expect_err("root label owned by a regular note should be rejected");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn create_root_reuses_existing_root_even_if_regular_note_shares_the_label() {
+        let mut store = store();
+
+        let first = create_root(&mut store, "Topic").expect("root should be created");
+        note_today(&mut store, "2026-04-11", "Topic").expect("note should be created");
+
+        let second = create_root(&mut store, "Topic").expect("existing root should be reused");
+
+        assert_eq!(first.root.id, second.root.id);
+    }
+
+    #[test]
+    fn create_root_rejects_labels_owned_by_root_aliases() {
+        let mut store = store();
+        let root = create_root(&mut store, "Alias owner").expect("root should be created");
+        add_aliases(&mut store, root.root.id, &[String::from("Topic")])
+            .expect("alias should be added");
+
+        let error =
+            create_root(&mut store, "Topic").expect_err("root alias should reserve the label");
         assert!(matches!(error, KernelError::Constraint(_)));
     }
 

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -457,22 +457,28 @@ fn choose_siblings<R: ReadRepository>(
     let mut chosen_prev = Vec::new();
     let mut chosen_next = Vec::new();
     let max_len = prev_candidates.len().max(next_candidates.len());
+    let mut stop_prev = false;
+    let mut stop_next = false;
 
     for index in 0..max_len {
-        if let Some(node) = prev_candidates.get(index) {
+        if !stop_prev && let Some(node) = prev_candidates.get(index) {
             let line = render_node_line(repository, node)?;
             let line_tokens = estimate_tokens(line.rendered_content.as_str()) + 8;
             if used_tokens + line_tokens <= soft_limit {
                 used_tokens += line_tokens;
                 chosen_prev.push(line);
+            } else {
+                stop_prev = true;
             }
         }
-        if let Some(node) = next_candidates.get(index) {
+        if !stop_next && let Some(node) = next_candidates.get(index) {
             let line = render_node_line(repository, node)?;
             let line_tokens = estimate_tokens(line.rendered_content.as_str()) + 8;
             if used_tokens + line_tokens <= soft_limit {
                 used_tokens += line_tokens;
                 chosen_next.push(line);
+            } else {
+                stop_next = true;
             }
         }
     }
@@ -764,6 +770,59 @@ mod tests {
         assert_eq!(view.prev_siblings[0].id, first.root.id);
         assert_eq!(view.next_siblings.len(), 1);
         assert_eq!(view.next_siblings[0].id, next.root.id);
+    }
+
+    #[test]
+    fn read_context_does_not_skip_hidden_nearest_siblings() {
+        let near_id = NodeId::new(1).expect("valid test id");
+        let far_id = NodeId::new(2).expect("valid test id");
+        let current_id = NodeId::new(3).expect("valid test id");
+        let repository = MalformedSearchRepository {
+            nodes: BTreeMap::from([
+                (
+                    near_id,
+                    StoredNode {
+                        id: near_id,
+                        content: ContentLine::parse("X".repeat(2000))
+                            .expect("content should parse"),
+                        parent_id: None,
+                        first_child_id: None,
+                        last_child_id: None,
+                        prev_sibling_id: Some(far_id),
+                        next_sibling_id: None,
+                    },
+                ),
+                (
+                    far_id,
+                    StoredNode {
+                        id: far_id,
+                        content: ContentLine::parse("Short").expect("content should parse"),
+                        parent_id: None,
+                        first_child_id: None,
+                        last_child_id: None,
+                        prev_sibling_id: None,
+                        next_sibling_id: Some(near_id),
+                    },
+                ),
+                (
+                    current_id,
+                    StoredNode {
+                        id: current_id,
+                        content: ContentLine::parse("Current").expect("content should parse"),
+                        parent_id: Some(NodeId::new(9).expect("valid test id")),
+                        first_child_id: None,
+                        last_child_id: None,
+                        prev_sibling_id: Some(near_id),
+                        next_sibling_id: None,
+                    },
+                ),
+            ]),
+            root_id: NodeId::new(99).expect("valid test id"),
+        };
+
+        let view = read_node_context(&repository, current_id, 10).expect("read should succeed");
+        assert!(view.prev_siblings.is_empty());
+        assert_eq!(view.prev_hidden_count, 2);
     }
 
     #[derive(Default)]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -10,6 +10,7 @@ use memoryroam_domain::{
     render_storage_content,
 };
 use memoryroam_write::update_nodes;
+use std::collections::BTreeSet;
 
 const DEFAULT_MATCH_LIMIT: usize = 50;
 
@@ -517,8 +518,16 @@ fn choose_backlinks<R: ReadRepository>(
     mut used_tokens: usize,
     soft_limit: usize,
 ) -> KernelResult<(Vec<BacklinkLine>, usize, usize)> {
-    let mut backlinks = Vec::new();
+    let mut seen_sources = BTreeSet::new();
+    let mut unique_backlink_inputs = Vec::new();
     for incoming in incoming_links {
+        if seen_sources.insert(incoming.source_node_id) {
+            unique_backlink_inputs.push(incoming);
+        }
+    }
+
+    let mut backlinks = Vec::new();
+    for incoming in unique_backlink_inputs {
         let line = BacklinkLine {
             source: NodeLine {
                 id: incoming.source_node_id,
@@ -533,7 +542,7 @@ fn choose_backlinks<R: ReadRepository>(
         backlinks.push(line);
     }
 
-    let hidden = incoming_links.len().saturating_sub(backlinks.len());
+    let hidden = seen_sources.len().saturating_sub(backlinks.len());
     Ok((backlinks, hidden, used_tokens))
 }
 
@@ -678,6 +687,15 @@ mod tests {
 
         let result = create_root(&mut store, "2026").expect("numeric root should be created");
         assert_eq!(result.root.rendered_content, "2026");
+    }
+
+    #[test]
+    fn create_root_accepts_double_colon_plain_text() {
+        let mut store = store();
+
+        let result =
+            create_root(&mut store, "std::fmt").expect("plain text root should be created");
+        assert_eq!(result.root.rendered_content, "std::fmt");
     }
 
     #[test]
@@ -904,6 +922,152 @@ mod tests {
         let error =
             create_root(&mut store, "See {{Topic}}").expect_err("link-bearing root should fail");
         assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn read_context_deduplicates_backlinks_from_the_same_source() {
+        #[derive(Default)]
+        struct Repository {
+            nodes: BTreeMap<NodeId, StoredNode>,
+            incoming_links: BTreeMap<NodeId, Vec<IncomingLinkRecord>>,
+        }
+
+        impl ReadRepository for Repository {
+            fn get_node(&self, node_id: NodeId) -> KernelResult<Option<StoredNode>> {
+                Ok(self.nodes.get(&node_id).cloned())
+            }
+
+            fn list_children(&self, _parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
+                Ok(Vec::new())
+            }
+
+            fn list_outgoing_links(&self, _node_id: NodeId) -> KernelResult<Vec<NodeId>> {
+                Ok(Vec::new())
+            }
+
+            fn list_incoming_links(
+                &self,
+                node_id: NodeId,
+            ) -> KernelResult<Vec<IncomingLinkRecord>> {
+                Ok(self
+                    .incoming_links
+                    .get(&node_id)
+                    .cloned()
+                    .unwrap_or_default())
+            }
+
+            fn list_aliases(&self, _node_id: NodeId) -> KernelResult<Vec<AliasText>> {
+                Ok(Vec::new())
+            }
+
+            fn fetch_node_contents(
+                &self,
+                node_ids: &BTreeSet<NodeId>,
+            ) -> KernelResult<BTreeMap<NodeId, ContentLine>> {
+                Ok(node_ids
+                    .iter()
+                    .filter_map(|node_id| {
+                        self.nodes
+                            .get(node_id)
+                            .map(|node| (*node_id, node.content.clone()))
+                    })
+                    .collect())
+            }
+
+            fn lookup_candidates(&self, _key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
+                Ok(Vec::new())
+            }
+
+            fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
+                Ok(format!("path:{node_id}"))
+            }
+
+            fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+                Ok(None)
+            }
+
+            fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+                Ok(Vec::new())
+            }
+
+            fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+                Ok(false)
+            }
+
+            fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+                Ok(false)
+            }
+
+            fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+                Ok(Vec::new())
+            }
+
+            fn find_root_node_by_content(
+                &self,
+                _content: &ContentLine,
+            ) -> KernelResult<Option<StoredNode>> {
+                Ok(None)
+            }
+
+            fn search_text_matches(&self, _needle: &str) -> KernelResult<Vec<StoredNode>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let target_id = NodeId::new(1).expect("valid test id");
+        let source_id = NodeId::new(2).expect("valid test id");
+        let repository = Repository {
+            nodes: BTreeMap::from([
+                (
+                    target_id,
+                    StoredNode {
+                        id: target_id,
+                        content: ContentLine::parse("Target").expect("content should parse"),
+                        parent_id: None,
+                        first_child_id: None,
+                        last_child_id: None,
+                        prev_sibling_id: None,
+                        next_sibling_id: None,
+                    },
+                ),
+                (
+                    source_id,
+                    StoredNode {
+                        id: source_id,
+                        content: ContentLine::parse("Source {{1}} {{1}}")
+                            .expect("content should parse"),
+                        parent_id: None,
+                        first_child_id: None,
+                        last_child_id: None,
+                        prev_sibling_id: None,
+                        next_sibling_id: None,
+                    },
+                ),
+            ]),
+            incoming_links: BTreeMap::from([(
+                target_id,
+                vec![
+                    IncomingLinkRecord {
+                        source_node_id: source_id,
+                        source_content: ContentLine::parse("Source {{1}} {{1}}")
+                            .expect("content should parse"),
+                        ordinal: 1,
+                        path: String::from("path:2"),
+                    },
+                    IncomingLinkRecord {
+                        source_node_id: source_id,
+                        source_content: ContentLine::parse("Source {{1}} {{1}}")
+                            .expect("content should parse"),
+                        ordinal: 2,
+                        path: String::from("path:2"),
+                    },
+                ],
+            )]),
+        };
+
+        let view = read_node_context(&repository, target_id, 5500).expect("read should succeed");
+        assert_eq!(view.backlinks.len(), 1);
+        assert_eq!(view.hidden_backlink_count, 0);
     }
 
     #[test]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -250,17 +250,18 @@ pub fn read_node_context<R: ReadRepository>(
     let soft_limit = budget_target.saturating_add(300);
     let mut used_tokens = current_tokens;
 
-    let (prev_candidates, next_candidates) =
-        if repository.is_daily_note_node(node_id)? || repository.is_root_node(node_id)? {
-            top_level_neighbors(repository, node_id)?
-        } else if node.parent_id.is_some() {
-            (
-                collect_previous_siblings(repository, &node)?,
-                collect_next_siblings(repository, &node)?,
-            )
-        } else {
-            (Vec::new(), Vec::new())
-        };
+    let (prev_candidates, next_candidates) = if repository.is_daily_note_node(node_id)? {
+        daily_note_neighbors(repository, node_id)?
+    } else if repository.is_root_node(node_id)? {
+        root_neighbors(repository, node_id)?
+    } else if node.parent_id.is_some() {
+        (
+            collect_previous_siblings(repository, &node)?,
+            collect_next_siblings(repository, &node)?,
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
 
     let sibling_selection = choose_siblings(
         repository,
@@ -426,24 +427,58 @@ fn collect_next_siblings<R: ReadRepository>(
     Ok(siblings)
 }
 
-fn top_level_neighbors<R: ReadRepository>(
+fn daily_note_neighbors<R: ReadRepository>(
     repository: &R,
     node_id: NodeId,
 ) -> KernelResult<(Vec<StoredNode>, Vec<StoredNode>)> {
-    let top_level_nodes = repository.list_children(None)?;
-    let current_index = top_level_nodes
+    let daily_notes = repository.list_daily_notes()?;
+    let current_index = daily_notes
+        .iter()
+        .position(|record| record.node_id == node_id)
+        .ok_or(KernelError::StorageCorruption(format!(
+            "missing daily note membership for node {node_id}"
+        )))?;
+
+    let previous = daily_notes[..current_index]
+        .iter()
+        .rev()
+        .map(|record| {
+            repository
+                .get_node(record.node_id)?
+                .ok_or(KernelError::StorageCorruption(format!(
+                    "missing daily note node {}",
+                    record.node_id
+                )))
+        })
+        .collect::<KernelResult<Vec<_>>>()?;
+    let next = daily_notes[current_index + 1..]
+        .iter()
+        .map(|record| {
+            repository
+                .get_node(record.node_id)?
+                .ok_or(KernelError::StorageCorruption(format!(
+                    "missing daily note node {}",
+                    record.node_id
+                )))
+        })
+        .collect::<KernelResult<Vec<_>>>()?;
+    Ok((previous, next))
+}
+
+fn root_neighbors<R: ReadRepository>(
+    repository: &R,
+    node_id: NodeId,
+) -> KernelResult<(Vec<StoredNode>, Vec<StoredNode>)> {
+    let root_nodes = repository.list_root_nodes()?;
+    let current_index = root_nodes
         .iter()
         .position(|node| node.id == node_id)
         .ok_or(KernelError::StorageCorruption(format!(
             "missing root membership for node {node_id}"
         )))?;
 
-    let previous = top_level_nodes[..current_index]
-        .iter()
-        .rev()
-        .cloned()
-        .collect();
-    let next = top_level_nodes[current_index + 1..].to_vec();
+    let previous = root_nodes[..current_index].iter().rev().cloned().collect();
+    let next = root_nodes[current_index + 1..].to_vec();
     Ok((previous, next))
 }
 
@@ -770,6 +805,22 @@ mod tests {
         assert_eq!(view.prev_siblings[0].id, first.root.id);
         assert_eq!(view.next_siblings.len(), 1);
         assert_eq!(view.next_siblings[0].id, next.root.id);
+    }
+
+    #[test]
+    fn read_root_ignores_daily_notes_when_picking_neighbors() {
+        let mut store = store();
+
+        let first = create_root(&mut store, "Alpha").expect("first root should be created");
+        let current = create_root(&mut store, "Beta").expect("current root should be created");
+        store
+            .create_daily_note_node("2026-04-12")
+            .expect("daily note should be created");
+
+        let view = read_node_context(&store, current.root.id, 5500).expect("read should succeed");
+        assert_eq!(view.prev_siblings.len(), 1);
+        assert_eq!(view.prev_siblings[0].id, first.root.id);
+        assert!(view.next_siblings.is_empty());
     }
 
     #[test]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -5,8 +5,8 @@
 
 use chrono::NaiveDate;
 use memoryroam_domain::{
-    ContentFragment, ContentLine, IncomingLinkRecord, KernelError, KernelResult, NodeId, NodeLine,
-    ParsedLink, ReadRepository, StoredNode, canonicalize_content, parse_content,
+    ContentFragment, ContentLine, IncomingLinkRecord, KernelError, KernelResult, LookupKey, NodeId,
+    NodeLine, ParsedLink, ReadRepository, StoredNode, canonicalize_content, parse_content,
     render_storage_content,
 };
 use memoryroam_write::update_nodes;
@@ -120,6 +120,7 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     ensure_plain_text_root(&content)?;
     ensure_safe_root_label_text(content.as_str())?;
     ensure_referenceable_root_text(&content)?;
+    ensure_root_label_is_available(repository, &content)?;
     let search_text = normalized_root_lookup_text(&content);
     let mut rendered_matches = Vec::new();
     for node in repository.search_text_matches(search_text)? {
@@ -631,6 +632,22 @@ fn ensure_referenceable_root_text(content: &ContentLine) -> KernelResult<()> {
         .map_err(|error| KernelError::Input(error.to_string()))
 }
 
+fn ensure_root_label_is_available<R: ReadRepository>(
+    repository: &R,
+    content: &ContentLine,
+) -> KernelResult<()> {
+    let key = LookupKey::new(content.as_str().to_owned())
+        .map_err(|error| KernelError::Input(error.to_string()))?;
+    for candidate in repository.lookup_candidates(&key)? {
+        if !repository.is_root_node(candidate.node_id)? {
+            return Err(KernelError::Constraint(String::from(
+                "root label is already owned by a regular note",
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
     let fragments =
         parse_content(content).map_err(|error| KernelError::Input(error.to_string()))?;
@@ -726,6 +743,17 @@ mod tests {
             create_root(&mut store, " Topic ").expect("second root should reuse the first root");
 
         assert_eq!(first.root.id, second.root.id);
+    }
+
+    #[test]
+    fn create_root_rejects_labels_owned_by_regular_notes() {
+        let mut store = store();
+
+        note_today(&mut store, "2026-04-11", "Topic").expect("note should be created");
+
+        let error = create_root(&mut store, "Topic")
+            .expect_err("root label owned by a regular note should be rejected");
+        assert!(matches!(error, KernelError::Constraint(_)));
     }
 
     #[test]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -132,6 +132,7 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     let content =
         ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
     ensure_plain_text_root(&content)?;
+    ensure_safe_root_label_text(content.as_str())?;
     let root = match repository.find_root_node_by_content(&content)? {
         Some(node) => node,
         None => {
@@ -198,11 +199,7 @@ pub fn apply_root_link<R: ReadRepository + memoryroam_domain::WriteRepository>(
     }
 
     let target_text = target_text.unwrap_or(root.content.as_str());
-    if target_text.is_empty() || target_text.contains('\n') || target_text.contains('\r') {
-        return Err(KernelError::Input(String::from(
-            "root apply text must be a non-empty single line",
-        )));
-    }
+    ensure_safe_root_label_text(target_text)?;
 
     let mut updates = Vec::with_capacity(node_ids.len());
     for node_id in node_ids {
@@ -616,6 +613,20 @@ fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
     Ok(())
 }
 
+fn ensure_safe_root_label_text(text: &str) -> KernelResult<()> {
+    if text.is_empty() || text.contains('\n') || text.contains('\r') {
+        return Err(KernelError::Input(String::from(
+            "root apply text must be a non-empty single line",
+        )));
+    }
+    if text.contains("{{") || text.contains("}}") {
+        return Err(KernelError::Input(String::from(
+            "root text cannot contain raw link delimiters",
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -946,6 +957,15 @@ mod tests {
 
         let error =
             create_root(&mut store, "See {{Topic}}").expect_err("link-bearing root should fail");
+        assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn create_root_rejects_raw_closing_braces() {
+        let mut store = store();
+
+        let error =
+            create_root(&mut store, "foo}}bar").expect_err("raw closing braces should be rejected");
         assert!(matches!(error, KernelError::Input(_)));
     }
 

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -135,12 +135,21 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
         Some(node) => node,
         None => {
             let node = build_new_node(repository, raw_content)?;
-            let node_id = repository.create_root_node(&node)?;
-            repository
-                .get_node(node_id)?
-                .ok_or(KernelError::StorageCorruption(format!(
-                    "missing created root node {node_id}"
-                )))?
+            match repository.create_root_node(&node) {
+                Ok(node_id) => {
+                    repository
+                        .get_node(node_id)?
+                        .ok_or(KernelError::StorageCorruption(format!(
+                            "missing created root node {node_id}"
+                        )))?
+                }
+                Err(KernelError::Constraint(_)) => repository
+                    .find_root_node_by_content(&content)?
+                    .ok_or(KernelError::Constraint(String::from(
+                        "root could not be created or reused",
+                    )))?,
+                Err(error) => return Err(error),
+            }
         }
     };
 
@@ -199,6 +208,11 @@ pub fn apply_root_link<R: ReadRepository + memoryroam_domain::WriteRepository>(
         if repository.is_daily_note_node(*node_id)? {
             return Err(KernelError::Constraint(String::from(
                 "daily note date nodes are immutable",
+            )));
+        }
+        if repository.is_root_node(*node_id)? {
+            return Err(KernelError::Constraint(String::from(
+                "root nodes cannot be rewritten",
             )));
         }
 
@@ -890,5 +904,180 @@ mod tests {
         let error =
             create_root(&mut store, "See {{Topic}}").expect_err("link-bearing root should fail");
         assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn apply_root_rejects_root_nodes_as_targets() {
+        let mut store = store();
+
+        let first = create_root(&mut store, "Topic").expect("first root should be created");
+        let second = create_root(&mut store, "Topic map").expect("second root should be created");
+
+        let error = apply_root_link(&mut store, first.root.id, None, &[second.root.id])
+            .expect_err("root nodes should not be rewritten");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[derive(Default)]
+    struct RootRaceRepository {
+        existing_root: Option<StoredNode>,
+        create_attempts: usize,
+    }
+
+    impl ReadRepository for RootRaceRepository {
+        fn get_node(&self, node_id: NodeId) -> KernelResult<Option<StoredNode>> {
+            Ok(self
+                .existing_root
+                .as_ref()
+                .filter(|node| node.id == node_id)
+                .cloned())
+        }
+
+        fn list_children(&self, _parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+
+        fn list_outgoing_links(&self, _node_id: NodeId) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn list_incoming_links(&self, _node_id: NodeId) -> KernelResult<Vec<IncomingLinkRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn list_aliases(&self, _node_id: NodeId) -> KernelResult<Vec<AliasText>> {
+            Ok(Vec::new())
+        }
+
+        fn fetch_node_contents(
+            &self,
+            _node_ids: &BTreeSet<NodeId>,
+        ) -> KernelResult<BTreeMap<NodeId, ContentLine>> {
+            Ok(BTreeMap::new())
+        }
+
+        fn lookup_candidates(&self, _key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
+            Ok(Vec::new())
+        }
+
+        fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
+            Ok(format!("path:{node_id}"))
+        }
+
+        fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+            Ok(None)
+        }
+
+        fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+            Ok(self
+                .existing_root
+                .as_ref()
+                .is_some_and(|node| node.id == node_id))
+        }
+
+        fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+            Ok(self.existing_root.clone().into_iter().collect())
+        }
+
+        fn find_root_node_by_content(
+            &self,
+            _content: &ContentLine,
+        ) -> KernelResult<Option<StoredNode>> {
+            Ok(self.existing_root.clone())
+        }
+
+        fn search_text_matches(&self, _needle: &str) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl WriteRepository for RootRaceRepository {
+        fn init_schema(&mut self) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_nodes_from_lines(
+            &mut self,
+            _placement: Placement,
+            _lines: &[ContentLine],
+            _aliases: &[AliasText],
+        ) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn create_nodes(
+            &mut self,
+            _placement: Placement,
+            _nodes: &[NewNodeRecord],
+        ) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn update_node_contents(
+            &mut self,
+            _updates: &[memoryroam_domain::NodeUpdateRecord],
+        ) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn move_node(&mut self, _node_id: NodeId, _placement: Placement) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn delete_node(
+            &mut self,
+            _node_id: NodeId,
+            _mode: memoryroam_domain::DeleteMode,
+        ) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn add_aliases(&mut self, _node_id: NodeId, _aliases: &[AliasText]) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn remove_alias(&mut self, _node_id: NodeId, _alias: &AliasText) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_root_node(&mut self, node: &NewNodeRecord) -> KernelResult<NodeId> {
+            self.create_attempts += 1;
+            let node_id = NodeId::new(1).expect("valid test id");
+            self.existing_root = Some(StoredNode {
+                id: node_id,
+                content: node.content.clone(),
+                parent_id: None,
+                first_child_id: None,
+                last_child_id: None,
+                prev_sibling_id: None,
+                next_sibling_id: None,
+            });
+            Err(KernelError::Constraint(String::from(
+                "duplicate root lookup key",
+            )))
+        }
+
+        fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> {
+            Ok(NodeId::new(1).expect("valid test id"))
+        }
+    }
+
+    #[test]
+    fn create_root_reuses_existing_root_after_conflicting_create() {
+        let mut repository = RootRaceRepository::default();
+
+        let result = create_root(&mut repository, "Topic")
+            .expect("root should be reused after conflicting insert");
+
+        assert_eq!(result.root.id, NodeId::new(1).expect("valid test id"));
+        assert_eq!(repository.create_attempts, 1);
     }
 }

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(rustdoc::private_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
+use chrono::NaiveDate;
 use memoryroam_domain::{
     ContentFragment, ContentLine, IncomingLinkRecord, KernelError, KernelResult, NodeId, NodeLine,
     ParsedLink, ReadRepository, StoredNode, canonicalize_content, parse_content,
@@ -74,6 +75,7 @@ pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
     note_date: &str,
     raw_content: &str,
 ) -> KernelResult<NoteResult> {
+    validate_day_date(note_date, "invalid daily note date")?;
     let node = build_new_node(repository, raw_content)?;
     let note_node_id = match repository.find_daily_note(note_date)? {
         Some(record) => record.node_id,
@@ -106,6 +108,7 @@ pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
 }
 
 pub fn open_day<R: ReadRepository>(repository: &R, note_date: &str) -> KernelResult<DayView> {
+    validate_day_date(note_date, "invalid day date")?;
     let entries = match repository.find_daily_note(note_date)? {
         Some(record) => repository
             .list_children(Some(record.node_id))?
@@ -560,6 +563,12 @@ fn estimate_tokens(text: &str) -> usize {
     8 + non_ascii_count + ascii_count.div_ceil(3)
 }
 
+fn validate_day_date(note_date: &str, error_message: &str) -> KernelResult<()> {
+    NaiveDate::parse_from_str(note_date, "%F")
+        .map(|_| ())
+        .map_err(|_| KernelError::Input(String::from(error_message)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -627,6 +636,14 @@ mod tests {
             create_root(&mut store, " Topic ").expect("second root should reuse the first root");
 
         assert_eq!(first.root.id, second.root.id);
+    }
+
+    #[test]
+    fn create_root_accepts_numeric_content() {
+        let mut store = store();
+
+        let result = create_root(&mut store, "2026").expect("numeric root should be created");
+        assert_eq!(result.root.rendered_content, "2026");
     }
 
     #[derive(Default)]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -155,7 +155,7 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     };
 
     let root_line = render_node_line(repository, &root)?;
-    let search_text = root.content.as_str();
+    let search_text = normalized_root_lookup_text(&root.content);
     let mut matches = repository
         .search_text_matches(search_text)?
         .into_iter()
@@ -598,6 +598,10 @@ fn validate_day_date(note_date: &str, error_message: &str) -> KernelResult<()> {
         .map_err(|_| KernelError::Input(String::from(error_message)))
 }
 
+fn normalized_root_lookup_text(content: &ContentLine) -> &str {
+    content.as_str().trim()
+}
+
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
     let fragments =
         parse_content(content).map_err(|error| KernelError::Storage(error.to_string()))?;
@@ -710,8 +714,8 @@ mod tests {
             .create_nodes(Placement::LastChildOf(day_node), &[note])
             .expect("note should be created");
 
-        let first = create_root(&mut store, "Topic").expect("first root should succeed");
-        let second = create_root(&mut store, " Topic ").expect("second root should succeed");
+        let first = create_root(&mut store, " Topic ").expect("first root should succeed");
+        let second = create_root(&mut store, "Topic").expect("second root should succeed");
 
         assert_eq!(first.root.id, second.root.id);
         assert_eq!(first.matches, second.matches);

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -78,6 +78,7 @@ pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
 ) -> KernelResult<NoteResult> {
     validate_day_date(note_date, "invalid daily note date")?;
     let node = build_new_node(repository, raw_content)?;
+    let rendered_content = render_storage_content(repository, &node.content)?;
     let note_node_id = match repository.find_daily_note(note_date)? {
         Some(record) => record.node_id,
         None => match repository.create_daily_note_node(note_date) {
@@ -104,7 +105,10 @@ pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
 
     Ok(NoteResult {
         note_date: note_date.to_owned(),
-        node: render_node_line(repository, &created)?,
+        node: NodeLine {
+            id: created.id,
+            rendered_content,
+        },
     })
 }
 
@@ -133,6 +137,19 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     ensure_plain_text_root(&content)?;
     ensure_safe_root_label_text(content.as_str())?;
     ensure_referenceable_root_text(&content)?;
+    let search_text = normalized_root_lookup_text(&content);
+    let mut rendered_matches = Vec::new();
+    for node in repository.search_text_matches(search_text)? {
+        if plain_text_contains(&node.content, search_text)? {
+            rendered_matches.push(render_node_line(repository, &node)?);
+        }
+    }
+    rendered_matches.sort_by(|left, right| {
+        match_rank(left.rendered_content.as_str(), search_text)
+            .cmp(&match_rank(right.rendered_content.as_str(), search_text))
+            .then_with(|| left.id.value().cmp(&right.id.value()))
+    });
+
     let root = match repository.find_root_node_by_content(&content)? {
         Some(node) => node,
         None => {
@@ -156,21 +173,11 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     };
 
     let root_line = render_node_line(repository, &root)?;
-    let search_text = normalized_root_lookup_text(&root.content);
-    let mut matches = Vec::new();
-    for node in repository.search_text_matches(search_text)? {
-        if plain_text_contains(&node.content, search_text)? {
-            matches.push(node);
-        }
-    }
-    matches.sort_by(|left, right| compare_match_order(left, right, search_text));
-
-    let hidden_match_count = matches.len().saturating_sub(DEFAULT_MATCH_LIMIT);
-    let matches = matches
+    let hidden_match_count = rendered_matches.len().saturating_sub(DEFAULT_MATCH_LIMIT);
+    let matches = rendered_matches
         .into_iter()
         .take(DEFAULT_MATCH_LIMIT)
-        .map(|node| render_node_line(repository, &node))
-        .collect::<KernelResult<Vec<_>>>()?;
+        .collect::<Vec<_>>();
 
     Ok(RootCreateResult {
         root: root_line,
@@ -340,12 +347,6 @@ fn render_node_line<R: ReadRepository>(
         id: node.id,
         rendered_content: render_storage_content(repository, &node.content)?,
     })
-}
-
-fn compare_match_order(left: &StoredNode, right: &StoredNode, needle: &str) -> std::cmp::Ordering {
-    match_rank(left.content.as_str(), needle)
-        .cmp(&match_rank(right.content.as_str(), needle))
-        .then_with(|| left.id.value().cmp(&right.id.value()))
 }
 
 fn match_rank(content: &str, needle: &str) -> u8 {
@@ -1014,6 +1015,220 @@ mod tests {
 
         assert_eq!(result.note_date, "2026-04-11");
         assert_eq!(repository.create_daily_note_attempts, 1);
+    }
+
+    #[derive(Default)]
+    struct FailingMutationRepository {
+        nodes: BTreeMap<NodeId, StoredNode>,
+        aliases: BTreeMap<String, Vec<NodeId>>,
+        created_root: bool,
+        created_note: bool,
+    }
+
+    impl ReadRepository for FailingMutationRepository {
+        fn get_node(&self, node_id: NodeId) -> KernelResult<Option<StoredNode>> {
+            Ok(self.nodes.get(&node_id).cloned())
+        }
+
+        fn list_children(&self, _parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+
+        fn list_outgoing_links(&self, _node_id: NodeId) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn list_incoming_links(&self, _node_id: NodeId) -> KernelResult<Vec<IncomingLinkRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn list_aliases(&self, _node_id: NodeId) -> KernelResult<Vec<AliasText>> {
+            Ok(Vec::new())
+        }
+
+        fn fetch_node_contents(
+            &self,
+            node_ids: &BTreeSet<NodeId>,
+        ) -> KernelResult<BTreeMap<NodeId, ContentLine>> {
+            Ok(node_ids
+                .iter()
+                .filter_map(|node_id| {
+                    self.nodes
+                        .get(node_id)
+                        .map(|node| (*node_id, node.content.clone()))
+                })
+                .collect())
+        }
+
+        fn lookup_candidates(&self, key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
+            let ids = self.aliases.get(key.as_str()).cloned().unwrap_or_default();
+            Ok(ids
+                .into_iter()
+                .map(|node_id| LookupCandidate {
+                    node_id,
+                    content: self
+                        .nodes
+                        .get(&node_id)
+                        .expect("candidate should exist")
+                        .content
+                        .clone(),
+                    path: format!("path:{node_id}"),
+                })
+                .collect())
+        }
+
+        fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
+            Ok(format!("path:{node_id}"))
+        }
+
+        fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+            Ok(Some(DailyNoteRecord {
+                note_date: String::from("2026-04-12"),
+                node_id: NodeId::new(1).expect("valid test id"),
+            }))
+        }
+
+        fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+            Ok(node_id == NodeId::new(1).expect("valid test id"))
+        }
+
+        fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+            Ok(self
+                .nodes
+                .get(&NodeId::new(1).expect("valid test id"))
+                .cloned()
+                .into_iter()
+                .collect())
+        }
+
+        fn find_root_node_by_content(
+            &self,
+            _content: &ContentLine,
+        ) -> KernelResult<Option<StoredNode>> {
+            Ok(None)
+        }
+
+        fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+            Ok(self
+                .nodes
+                .values()
+                .filter(|node| node.content.as_str().contains(needle))
+                .cloned()
+                .collect())
+        }
+    }
+
+    impl WriteRepository for FailingMutationRepository {
+        fn init_schema(&mut self) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_nodes_from_lines(
+            &mut self,
+            _placement: Placement,
+            _lines: &[ContentLine],
+            _aliases: &[AliasText],
+        ) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn create_nodes(
+            &mut self,
+            _placement: Placement,
+            _nodes: &[NewNodeRecord],
+        ) -> KernelResult<Vec<NodeId>> {
+            self.created_note = true;
+            Ok(vec![NodeId::new(2).expect("valid test id")])
+        }
+
+        fn update_node_contents(
+            &mut self,
+            _updates: &[memoryroam_domain::NodeUpdateRecord],
+        ) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn move_node(&mut self, _node_id: NodeId, _placement: Placement) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn delete_node(
+            &mut self,
+            _node_id: NodeId,
+            _mode: memoryroam_domain::DeleteMode,
+        ) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn add_aliases(&mut self, _node_id: NodeId, _aliases: &[AliasText]) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn remove_alias(&mut self, _node_id: NodeId, _alias: &AliasText) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_root_node(&mut self, _node: &NewNodeRecord) -> KernelResult<NodeId> {
+            self.created_root = true;
+            Ok(NodeId::new(3).expect("valid test id"))
+        }
+
+        fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> {
+            Ok(NodeId::new(1).expect("valid test id"))
+        }
+    }
+
+    #[test]
+    fn note_today_does_not_write_when_rendering_would_fail() {
+        let target_id = NodeId::new(9).expect("valid test id");
+        let mut repository = FailingMutationRepository::default();
+        repository.nodes.insert(
+            target_id,
+            StoredNode {
+                id: target_id,
+                content: ContentLine::parse("Broken {{oops").expect("content should parse"),
+                parent_id: None,
+                first_child_id: None,
+                last_child_id: None,
+                prev_sibling_id: None,
+                next_sibling_id: None,
+            },
+        );
+
+        note_today(&mut repository, "2026-04-12", "See {{9}}")
+            .expect_err("note should fail before writing");
+        assert!(!repository.created_note);
+    }
+
+    #[test]
+    fn create_root_does_not_write_when_match_rendering_would_fail() {
+        let target_id = NodeId::new(1).expect("valid test id");
+        let mut repository = FailingMutationRepository::default();
+        repository.nodes.insert(
+            target_id,
+            StoredNode {
+                id: target_id,
+                content: ContentLine::parse("Broken {{oops").expect("content should parse"),
+                parent_id: None,
+                first_child_id: None,
+                last_child_id: None,
+                prev_sibling_id: None,
+                next_sibling_id: None,
+            },
+        );
+
+        let error =
+            create_root(&mut repository, "Broken").expect_err("root should fail before writing");
+        assert!(matches!(error, KernelError::Storage(_)));
+        assert!(!repository.created_root);
     }
 
     #[test]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -155,7 +155,7 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     };
 
     let root_line = render_node_line(repository, &root)?;
-    let search_text = root.content.as_str().trim();
+    let search_text = root.content.as_str();
     let mut matches = repository
         .search_text_matches(search_text)?
         .into_iter()
@@ -197,7 +197,7 @@ pub fn apply_root_link<R: ReadRepository + memoryroam_domain::WriteRepository>(
         ensure_plain_text_root(&root.content)?;
     }
 
-    let target_text = target_text.unwrap_or(root.content.as_str()).trim();
+    let target_text = target_text.unwrap_or(root.content.as_str());
     if target_text.is_empty() || target_text.contains('\n') || target_text.contains('\r') {
         return Err(KernelError::Input(String::from(
             "root apply text must be a non-empty single line",
@@ -715,6 +715,27 @@ mod tests {
 
         assert_eq!(first.root.id, second.root.id);
         assert_eq!(first.matches, second.matches);
+    }
+
+    #[test]
+    fn apply_root_preserves_surrounding_whitespace_in_default_text() {
+        let mut store = store();
+
+        let root = create_root(&mut store, " Topic ").expect("root should be created");
+        let day_node = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note should be created");
+        let note = build_new_node(&store, "alpha  Topic  omega").expect("note should build");
+        let note_id = store
+            .create_nodes(Placement::LastChildOf(day_node), &[note])
+            .expect("note should be created")[0];
+
+        let result = apply_root_link(&mut store, root.root.id, None, &[note_id])
+            .expect("apply should succeed");
+        assert_eq!(
+            result.updated_nodes[0].rendered_content,
+            format!("alpha {{{{{}:: Topic }}}} omega", root.root.id)
+        );
     }
 
     #[derive(Default)]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -644,7 +644,7 @@ fn ensure_referenceable_root_text(content: &ContentLine) -> KernelResult<()> {
 
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
     let fragments =
-        parse_content(content).map_err(|error| KernelError::Storage(error.to_string()))?;
+        parse_content(content).map_err(|error| KernelError::Input(error.to_string()))?;
     if fragments
         .iter()
         .any(|fragment| matches!(fragment, ContentFragment::Link(_)))
@@ -1031,6 +1031,15 @@ mod tests {
 
         let error =
             create_root(&mut store, "foo}}bar").expect_err("raw closing braces should be rejected");
+        assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn create_root_reports_malformed_link_prefix_as_input_error() {
+        let mut store = store();
+
+        let error =
+            create_root(&mut store, "Broken {{oops").expect_err("malformed root should fail");
         assert!(matches!(error, KernelError::Input(_)));
     }
 

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -79,24 +79,7 @@ pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
     validate_day_date(note_date, "invalid daily note date")?;
     let node = build_new_node(repository, raw_content)?;
     let rendered_content = render_storage_content(repository, &node.content)?;
-    let note_node_id = match repository.find_daily_note(note_date)? {
-        Some(record) => record.node_id,
-        None => match repository.create_daily_note_node(note_date) {
-            Ok(node_id) => node_id,
-            Err(KernelError::Constraint(_)) => repository
-                .find_daily_note(note_date)?
-                .map(|record| record.node_id)
-                .ok_or(KernelError::Constraint(format!(
-                    "daily note {note_date} could not be created"
-                )))?,
-            Err(error) => return Err(error),
-        },
-    };
-
-    let node_id = repository.create_nodes(
-        memoryroam_domain::Placement::LastChildOf(note_node_id),
-        &[node],
-    )?[0];
+    let node_id = repository.create_note_in_daily_note(note_date, &node)?;
     let created = repository
         .get_node(node_id)?
         .ok_or(KernelError::StorageCorruption(format!(
@@ -267,18 +250,17 @@ pub fn read_node_context<R: ReadRepository>(
     let soft_limit = budget_target.saturating_add(300);
     let mut used_tokens = current_tokens;
 
-    let (prev_candidates, next_candidates) = if repository.is_daily_note_node(node_id)? {
-        daily_note_neighbors(repository, node_id)?
-    } else if repository.is_root_node(node_id)? {
-        root_neighbors(repository, node_id)?
-    } else if node.parent_id.is_some() {
-        (
-            collect_previous_siblings(repository, &node)?,
-            collect_next_siblings(repository, &node)?,
-        )
-    } else {
-        (Vec::new(), Vec::new())
-    };
+    let (prev_candidates, next_candidates) =
+        if repository.is_daily_note_node(node_id)? || repository.is_root_node(node_id)? {
+            top_level_neighbors(repository, node_id)?
+        } else if node.parent_id.is_some() {
+            (
+                collect_previous_siblings(repository, &node)?,
+                collect_next_siblings(repository, &node)?,
+            )
+        } else {
+            (Vec::new(), Vec::new())
+        };
 
     let sibling_selection = choose_siblings(
         repository,
@@ -444,59 +426,24 @@ fn collect_next_siblings<R: ReadRepository>(
     Ok(siblings)
 }
 
-fn daily_note_neighbors<R: ReadRepository>(
+fn top_level_neighbors<R: ReadRepository>(
     repository: &R,
     node_id: NodeId,
 ) -> KernelResult<(Vec<StoredNode>, Vec<StoredNode>)> {
-    let daily_notes = repository.list_daily_notes()?;
-    let current_index = daily_notes
-        .iter()
-        .position(|record| record.node_id == node_id)
-        .ok_or(KernelError::StorageCorruption(format!(
-            "missing daily note membership for node {node_id}"
-        )))?;
-
-    let previous = daily_notes[..current_index]
-        .iter()
-        .rev()
-        .map(|record| {
-            repository
-                .get_node(record.node_id)?
-                .ok_or(KernelError::StorageCorruption(format!(
-                    "missing daily note node {}",
-                    record.node_id
-                )))
-        })
-        .collect::<KernelResult<Vec<_>>>()?;
-    let next = daily_notes[current_index + 1..]
-        .iter()
-        .map(|record| {
-            repository
-                .get_node(record.node_id)?
-                .ok_or(KernelError::StorageCorruption(format!(
-                    "missing daily note node {}",
-                    record.node_id
-                )))
-        })
-        .collect::<KernelResult<Vec<_>>>()?;
-
-    Ok((previous, next))
-}
-
-fn root_neighbors<R: ReadRepository>(
-    repository: &R,
-    node_id: NodeId,
-) -> KernelResult<(Vec<StoredNode>, Vec<StoredNode>)> {
-    let root_nodes = repository.list_root_nodes()?;
-    let current_index = root_nodes
+    let top_level_nodes = repository.list_children(None)?;
+    let current_index = top_level_nodes
         .iter()
         .position(|node| node.id == node_id)
         .ok_or(KernelError::StorageCorruption(format!(
             "missing root membership for node {node_id}"
         )))?;
 
-    let previous = root_nodes[..current_index].iter().rev().cloned().collect();
-    let next = root_nodes[current_index + 1..].to_vec();
+    let previous = top_level_nodes[..current_index]
+        .iter()
+        .rev()
+        .cloned()
+        .collect();
+    let next = top_level_nodes[current_index + 1..].to_vec();
     Ok((previous, next))
 }
 
@@ -1001,6 +948,31 @@ mod tests {
 
             panic!("note_today should retry by re-reading the daily note");
         }
+
+        fn create_note_in_daily_note(
+            &mut self,
+            note_date: &str,
+            node: &NewNodeRecord,
+        ) -> KernelResult<NodeId> {
+            let note_node_id = match self.find_daily_note(note_date)? {
+                Some(record) => record.node_id,
+                None => match self.create_daily_note_node(note_date) {
+                    Ok(node_id) => node_id,
+                    Err(KernelError::Constraint(_)) => self
+                        .find_daily_note(note_date)?
+                        .map(|record| record.node_id)
+                        .ok_or(KernelError::Constraint(String::from(
+                            "daily note could not be created",
+                        )))?,
+                    Err(error) => return Err(error),
+                },
+            };
+            self.create_nodes(
+                Placement::LastChildOf(note_node_id),
+                std::slice::from_ref(node),
+            )
+            .map(|mut ids| ids.remove(0))
+        }
     }
 
     #[test]
@@ -1183,6 +1155,15 @@ mod tests {
 
         fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> {
             Ok(NodeId::new(1).expect("valid test id"))
+        }
+
+        fn create_note_in_daily_note(
+            &mut self,
+            _note_date: &str,
+            _node: &NewNodeRecord,
+        ) -> KernelResult<NodeId> {
+            self.created_note = true;
+            Ok(NodeId::new(2).expect("valid test id"))
         }
     }
 
@@ -1401,6 +1382,14 @@ mod tests {
         }
 
         fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn create_note_in_daily_note(
+            &mut self,
+            _note_date: &str,
+            _node: &NewNodeRecord,
+        ) -> KernelResult<NodeId> {
             Err(KernelError::Storage(String::from("unused in test")))
         }
     }
@@ -1751,6 +1740,14 @@ mod tests {
 
         fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> {
             Ok(NodeId::new(1).expect("valid test id"))
+        }
+
+        fn create_note_in_daily_note(
+            &mut self,
+            _note_date: &str,
+            _node: &NewNodeRecord,
+        ) -> KernelResult<NodeId> {
+            Err(KernelError::Storage(String::from("unused in test")))
         }
     }
 

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -129,14 +129,13 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     repository: &mut R,
     raw_content: &str,
 ) -> KernelResult<RootCreateResult> {
-    let content =
-        ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
+    let content = normalize_root_content(raw_content)?;
     ensure_plain_text_root(&content)?;
     ensure_safe_root_label_text(content.as_str())?;
     let root = match repository.find_root_node_by_content(&content)? {
         Some(node) => node,
         None => {
-            let node = build_new_node(repository, raw_content)?;
+            let node = build_root_node(repository, &content)?;
             match repository.create_root_node(&node) {
                 Ok(node_id) => {
                     repository
@@ -261,6 +260,8 @@ pub fn read_node_context<R: ReadRepository>(
 
     let (prev_candidates, next_candidates) = if repository.is_daily_note_node(node_id)? {
         daily_note_neighbors(repository, node_id)?
+    } else if repository.is_root_node(node_id)? {
+        root_neighbors(repository, node_id)?
     } else if node.parent_id.is_some() {
         (
             collect_previous_siblings(repository, &node)?,
@@ -308,6 +309,19 @@ fn build_new_node<R: ReadRepository>(
     let content =
         ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
     let canonical = canonicalize_content(repository, &content)?;
+    Ok(memoryroam_domain::NewNodeRecord {
+        content: canonical.content,
+        lookup_key: canonical.lookup_key,
+        outgoing_links: canonical.outgoing_links,
+        aliases: Vec::new(),
+    })
+}
+
+fn build_root_node<R: ReadRepository>(
+    repository: &R,
+    content: &ContentLine,
+) -> KernelResult<memoryroam_domain::NewNodeRecord> {
+    let canonical = canonicalize_content(repository, content)?;
     Ok(memoryroam_domain::NewNodeRecord {
         content: canonical.content,
         lookup_key: canonical.lookup_key,
@@ -466,6 +480,23 @@ fn daily_note_neighbors<R: ReadRepository>(
     Ok((previous, next))
 }
 
+fn root_neighbors<R: ReadRepository>(
+    repository: &R,
+    node_id: NodeId,
+) -> KernelResult<(Vec<StoredNode>, Vec<StoredNode>)> {
+    let root_nodes = repository.list_root_nodes()?;
+    let current_index = root_nodes
+        .iter()
+        .position(|node| node.id == node_id)
+        .ok_or(KernelError::StorageCorruption(format!(
+            "missing root membership for node {node_id}"
+        )))?;
+
+    let previous = root_nodes[..current_index].iter().rev().cloned().collect();
+    let next = root_nodes[current_index + 1..].to_vec();
+    Ok((previous, next))
+}
+
 fn choose_siblings<R: ReadRepository>(
     repository: &R,
     prev_candidates: Vec<StoredNode>,
@@ -595,6 +626,10 @@ fn validate_day_date(note_date: &str, error_message: &str) -> KernelResult<()> {
         .map_err(|_| KernelError::Input(String::from(error_message)))
 }
 
+fn normalize_root_content(raw_content: &str) -> KernelResult<ContentLine> {
+    ContentLine::parse(raw_content.trim()).map_err(|error| KernelError::Input(error.to_string()))
+}
+
 fn normalized_root_lookup_text(content: &ContentLine) -> &str {
     content.as_str().trim()
 }
@@ -714,6 +749,14 @@ mod tests {
     }
 
     #[test]
+    fn create_root_trims_surrounding_whitespace() {
+        let mut store = store();
+
+        let result = create_root(&mut store, " Topic ").expect("root should be created");
+        assert_eq!(result.root.rendered_content, "Topic");
+    }
+
+    #[test]
     fn create_root_reuses_consistent_match_search_text() {
         let mut store = store();
 
@@ -749,8 +792,23 @@ mod tests {
             .expect("apply should succeed");
         assert_eq!(
             result.updated_nodes[0].rendered_content,
-            format!("alpha {{{{{}:: Topic }}}} omega", root.root.id)
+            format!("alpha  {{{{{}::Topic}}}}  omega", root.root.id)
         );
+    }
+
+    #[test]
+    fn read_root_shows_neighboring_roots() {
+        let mut store = store();
+
+        let first = create_root(&mut store, "Alpha").expect("first root should be created");
+        let current = create_root(&mut store, "Beta").expect("current root should be created");
+        let next = create_root(&mut store, "Gamma").expect("next root should be created");
+
+        let view = read_node_context(&store, current.root.id, 5500).expect("read should succeed");
+        assert_eq!(view.prev_siblings.len(), 1);
+        assert_eq!(view.prev_siblings[0].id, first.root.id);
+        assert_eq!(view.next_siblings.len(), 1);
+        assert_eq!(view.next_siblings[0].id, next.root.id);
     }
 
     #[derive(Default)]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -130,6 +130,7 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
 ) -> KernelResult<RootCreateResult> {
     let content =
         ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
+    ensure_plain_text_root(&content)?;
     let root = match repository.find_root_node_by_content(&content)? {
         Some(node) => node,
         None => {
@@ -144,12 +145,13 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     };
 
     let root_line = render_node_line(repository, &root)?;
+    let search_text = root.content.as_str().trim();
     let mut matches = repository
-        .search_text_matches(content.as_str())?
+        .search_text_matches(search_text)?
         .into_iter()
-        .filter(|node| plain_text_contains(&node.content, content.as_str()).unwrap_or(false))
+        .filter(|node| plain_text_contains(&node.content, search_text).unwrap_or(false))
         .collect::<Vec<_>>();
-    matches.sort_by(|left, right| compare_match_order(left, right, content.as_str()));
+    matches.sort_by(|left, right| compare_match_order(left, right, search_text));
 
     let hidden_match_count = matches.len().saturating_sub(DEFAULT_MATCH_LIMIT);
     let matches = matches
@@ -181,7 +183,11 @@ pub fn apply_root_link<R: ReadRepository + memoryroam_domain::WriteRepository>(
         )));
     }
 
-    let target_text = target_text.unwrap_or(root.content.as_str());
+    if target_text.is_none() {
+        ensure_plain_text_root(&root.content)?;
+    }
+
+    let target_text = target_text.unwrap_or(root.content.as_str()).trim();
     if target_text.is_empty() || target_text.contains('\n') || target_text.contains('\r') {
         return Err(KernelError::Input(String::from(
             "root apply text must be a non-empty single line",
@@ -569,6 +575,20 @@ fn validate_day_date(note_date: &str, error_message: &str) -> KernelResult<()> {
         .map_err(|_| KernelError::Input(String::from(error_message)))
 }
 
+fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
+    let fragments =
+        parse_content(content).map_err(|error| KernelError::Storage(error.to_string()))?;
+    if fragments
+        .iter()
+        .any(|fragment| matches!(fragment, ContentFragment::Link(_)))
+    {
+        return Err(KernelError::Input(String::from(
+            "root content cannot contain links",
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -644,6 +664,25 @@ mod tests {
 
         let result = create_root(&mut store, "2026").expect("numeric root should be created");
         assert_eq!(result.root.rendered_content, "2026");
+    }
+
+    #[test]
+    fn create_root_reuses_consistent_match_search_text() {
+        let mut store = store();
+
+        let day_node = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note should be created");
+        let note = build_new_node(&store, "Topic appears here").expect("node should build");
+        store
+            .create_nodes(Placement::LastChildOf(day_node), &[note])
+            .expect("note should be created");
+
+        let first = create_root(&mut store, "Topic").expect("first root should succeed");
+        let second = create_root(&mut store, " Topic ").expect("second root should succeed");
+
+        assert_eq!(first.root.id, second.root.id);
+        assert_eq!(first.matches, second.matches);
     }
 
     #[derive(Default)]
@@ -842,5 +881,14 @@ mod tests {
 
         assert_eq!(result.note_date, "2026-04-11");
         assert_eq!(repository.create_daily_note_attempts, 1);
+    }
+
+    #[test]
+    fn create_root_rejects_link_bearing_content() {
+        let mut store = store();
+
+        let error =
+            create_root(&mut store, "See {{Topic}}").expect_err("link-bearing root should fail");
+        assert!(matches!(error, KernelError::Input(_)));
     }
 }

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -697,7 +697,7 @@ mod tests {
 
     use memoryroam_domain::{
         AliasText, DailyNoteRecord, IncomingLinkRecord, LookupCandidate, LookupKey, NewNodeRecord,
-        Placement, StoredNode, WriteRepository,
+        NodeUpdateRecord, Placement, StoredNode, WriteRepository,
     };
     use memoryroam_storage_sqlite::SqliteStore;
     use memoryroam_write::{add_aliases, init};
@@ -712,6 +712,181 @@ mod tests {
         let mut store = SqliteStore::open_or_create(path).expect("store should open");
         init(&mut store).expect("schema init should succeed");
         store
+    }
+
+    struct ConflictingRootRepository {
+        root: StoredNode,
+        note: StoredNode,
+    }
+
+    impl ReadRepository for ConflictingRootRepository {
+        fn get_node(&self, node_id: NodeId) -> KernelResult<Option<StoredNode>> {
+            if node_id == self.root.id {
+                return Ok(Some(self.root.clone()));
+            }
+            if node_id == self.note.id {
+                return Ok(Some(self.note.clone()));
+            }
+            Ok(None)
+        }
+
+        fn list_children(&self, _parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+
+        fn list_outgoing_links(&self, _node_id: NodeId) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn list_incoming_links(&self, _node_id: NodeId) -> KernelResult<Vec<IncomingLinkRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn list_aliases(&self, _node_id: NodeId) -> KernelResult<Vec<AliasText>> {
+            Ok(Vec::new())
+        }
+
+        fn fetch_node_contents(
+            &self,
+            node_ids: &BTreeSet<NodeId>,
+        ) -> KernelResult<BTreeMap<NodeId, ContentLine>> {
+            let mut contents = BTreeMap::new();
+            for node_id in node_ids {
+                if *node_id == self.root.id {
+                    contents.insert(*node_id, self.root.content.clone());
+                } else if *node_id == self.note.id {
+                    contents.insert(*node_id, self.note.content.clone());
+                }
+            }
+            Ok(contents)
+        }
+
+        fn lookup_candidates(&self, key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
+            if key.as_str() != "Topic" {
+                return Ok(Vec::new());
+            }
+
+            Ok(vec![
+                LookupCandidate {
+                    node_id: self.root.id,
+                    content: self.root.content.clone(),
+                    path: format!("path:{}", self.root.id),
+                },
+                LookupCandidate {
+                    node_id: self.note.id,
+                    content: self.note.content.clone(),
+                    path: format!("path:{}", self.note.id),
+                },
+            ])
+        }
+
+        fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
+            Ok(format!("path:{node_id}"))
+        }
+
+        fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+            Ok(None)
+        }
+
+        fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+            Ok(node_id == self.root.id)
+        }
+
+        fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+            Ok(vec![self.root.clone()])
+        }
+
+        fn find_root_node_by_content(
+            &self,
+            content: &ContentLine,
+        ) -> KernelResult<Option<StoredNode>> {
+            if content.as_str() == self.root.content.as_str() {
+                return Ok(Some(self.root.clone()));
+            }
+            Ok(None)
+        }
+
+        fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+            let mut matches = Vec::new();
+            if self.root.content.as_str().contains(needle) {
+                matches.push(self.root.clone());
+            }
+            if self.note.content.as_str().contains(needle) {
+                matches.push(self.note.clone());
+            }
+            Ok(matches)
+        }
+    }
+
+    impl WriteRepository for ConflictingRootRepository {
+        fn init_schema(&mut self) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_nodes_from_lines(
+            &mut self,
+            _placement: Placement,
+            _lines: &[ContentLine],
+            _aliases: &[AliasText],
+        ) -> KernelResult<Vec<NodeId>> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn create_nodes(
+            &mut self,
+            _placement: Placement,
+            _nodes: &[NewNodeRecord],
+        ) -> KernelResult<Vec<NodeId>> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn update_node_contents(&mut self, _updates: &[NodeUpdateRecord]) -> KernelResult<()> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn move_node(&mut self, _node_id: NodeId, _placement: Placement) -> KernelResult<()> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn delete_node(
+            &mut self,
+            _node_id: NodeId,
+            _mode: memoryroam_domain::DeleteMode,
+        ) -> KernelResult<()> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn add_aliases(&mut self, _node_id: NodeId, _aliases: &[AliasText]) -> KernelResult<()> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn remove_alias(&mut self, _node_id: NodeId, _alias: &AliasText) -> KernelResult<()> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn create_root_node(&mut self, _node: &NewNodeRecord) -> KernelResult<NodeId> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn create_note_in_daily_note(
+            &mut self,
+            _note_date: &str,
+            _node: &NewNodeRecord,
+        ) -> KernelResult<NodeId> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
     }
 
     #[test]
@@ -795,23 +970,32 @@ mod tests {
 
     #[test]
     fn create_root_reuses_existing_root_even_if_regular_note_shares_the_label() {
-        let mut store = store();
+        let root_id = NodeId::new(1).expect("valid test id");
+        let note_id = NodeId::new(2).expect("valid test id");
+        let mut repository = ConflictingRootRepository {
+            root: StoredNode {
+                id: root_id,
+                content: ContentLine::parse("Topic").expect("content should parse"),
+                parent_id: None,
+                first_child_id: None,
+                last_child_id: None,
+                prev_sibling_id: None,
+                next_sibling_id: None,
+            },
+            note: StoredNode {
+                id: note_id,
+                content: ContentLine::parse("Topic").expect("content should parse"),
+                parent_id: Some(NodeId::new(3).expect("valid test id")),
+                first_child_id: None,
+                last_child_id: None,
+                prev_sibling_id: None,
+                next_sibling_id: None,
+            },
+        };
 
-        let first = create_root(&mut store, "Topic").expect("root should be created");
-        let day_node_id = store
-            .create_daily_note_node("2026-04-11")
-            .expect("daily note should be created");
-        memoryroam_write::create_nodes(
-            &mut store,
-            "Topic",
-            &[],
-            Placement::LastChildOf(day_node_id),
-        )
-        .expect("low-level note create should succeed");
+        let reused = create_root(&mut repository, "Topic").expect("existing root should be reused");
 
-        let second = create_root(&mut store, "Topic").expect("existing root should be reused");
-
-        assert_eq!(first.root.id, second.root.id);
+        assert_eq!(reused.root.id, root_id);
     }
 
     #[test]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -78,6 +78,7 @@ pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
 ) -> KernelResult<NoteResult> {
     validate_day_date(note_date, "invalid daily note date")?;
     let node = build_new_node(repository, raw_content)?;
+    ensure_note_lookup_key_is_available(repository, &node.lookup_key)?;
     let rendered_content = render_storage_content(repository, &node.content)?;
     let node_id = repository.create_note_in_daily_note(note_date, &node)?;
     let created = repository
@@ -647,6 +648,20 @@ fn ensure_root_label_is_available<R: ReadRepository>(
     )))
 }
 
+fn ensure_note_lookup_key_is_available<R: ReadRepository>(
+    repository: &R,
+    lookup_key: &LookupKey,
+) -> KernelResult<()> {
+    for candidate in repository.lookup_candidates(lookup_key)? {
+        if repository.is_root_node(candidate.node_id)? {
+            return Err(KernelError::Constraint(String::from(
+                "note content cannot reuse a root label",
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
     let fragments =
         parse_content(content).map_err(|error| KernelError::Input(error.to_string()))?;
@@ -745,6 +760,29 @@ mod tests {
     }
 
     #[test]
+    fn note_today_rejects_content_that_reuses_root_labels() {
+        let mut store = store();
+
+        create_root(&mut store, "Topic").expect("root should be created");
+
+        let error = note_today(&mut store, "2026-04-11", "Topic")
+            .expect_err("note should reject root-owned lookup key");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn note_today_rejects_content_that_reuses_root_aliases() {
+        let mut store = store();
+        let root = create_root(&mut store, "Alias owner").expect("root should be created");
+        add_aliases(&mut store, root.root.id, &[String::from("Topic")])
+            .expect("alias should be added");
+
+        let error = note_today(&mut store, "2026-04-11", "Topic")
+            .expect_err("note should reject root alias-owned lookup key");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
     fn create_root_rejects_labels_owned_by_regular_notes() {
         let mut store = store();
 
@@ -760,7 +798,16 @@ mod tests {
         let mut store = store();
 
         let first = create_root(&mut store, "Topic").expect("root should be created");
-        note_today(&mut store, "2026-04-11", "Topic").expect("note should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note should be created");
+        memoryroam_write::create_nodes(
+            &mut store,
+            "Topic",
+            &[],
+            Placement::LastChildOf(day_node_id),
+        )
+        .expect("low-level note create should succeed");
 
         let second = create_root(&mut store, "Topic").expect("existing root should be reused");
 

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -132,6 +132,7 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
     let content = normalize_root_content(raw_content)?;
     ensure_plain_text_root(&content)?;
     ensure_safe_root_label_text(content.as_str())?;
+    ensure_referenceable_root_text(&content)?;
     let root = match repository.find_root_node_by_content(&content)? {
         Some(node) => node,
         None => {
@@ -156,11 +157,12 @@ pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
 
     let root_line = render_node_line(repository, &root)?;
     let search_text = normalized_root_lookup_text(&root.content);
-    let mut matches = repository
-        .search_text_matches(search_text)?
-        .into_iter()
-        .filter(|node| plain_text_contains(&node.content, search_text).unwrap_or(false))
-        .collect::<Vec<_>>();
+    let mut matches = Vec::new();
+    for node in repository.search_text_matches(search_text)? {
+        if plain_text_contains(&node.content, search_text)? {
+            matches.push(node);
+        }
+    }
     matches.sort_by(|left, right| compare_match_order(left, right, search_text));
 
     let hidden_match_count = matches.len().saturating_sub(DEFAULT_MATCH_LIMIT);
@@ -634,6 +636,12 @@ fn normalized_root_lookup_text(content: &ContentLine) -> &str {
     content.as_str().trim()
 }
 
+fn ensure_referenceable_root_text(content: &ContentLine) -> KernelResult<()> {
+    memoryroam_domain::LookupKey::new(content.as_str().to_owned())
+        .map(|_| ())
+        .map_err(|error| KernelError::Input(error.to_string()))
+}
+
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
     let fragments =
         parse_content(content).map_err(|error| KernelError::Storage(error.to_string()))?;
@@ -732,20 +740,19 @@ mod tests {
     }
 
     #[test]
-    fn create_root_accepts_numeric_content() {
+    fn create_root_rejects_numeric_content() {
         let mut store = store();
 
-        let result = create_root(&mut store, "2026").expect("numeric root should be created");
-        assert_eq!(result.root.rendered_content, "2026");
+        let error = create_root(&mut store, "2026").expect_err("numeric root should be rejected");
+        assert!(matches!(error, KernelError::Input(_)));
     }
 
     #[test]
-    fn create_root_accepts_double_colon_plain_text() {
+    fn create_root_rejects_double_colon_plain_text() {
         let mut store = store();
 
-        let result =
-            create_root(&mut store, "std::fmt").expect("plain text root should be created");
-        assert_eq!(result.root.rendered_content, "std::fmt");
+        let error = create_root(&mut store, "std::fmt").expect_err("double colon root should fail");
+        assert!(matches!(error, KernelError::Input(_)));
     }
 
     #[test]
@@ -1025,6 +1032,192 @@ mod tests {
         let error =
             create_root(&mut store, "foo}}bar").expect_err("raw closing braces should be rejected");
         assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    struct MalformedSearchRepository {
+        nodes: BTreeMap<NodeId, StoredNode>,
+        root_id: NodeId,
+    }
+
+    impl ReadRepository for MalformedSearchRepository {
+        fn get_node(&self, node_id: NodeId) -> KernelResult<Option<StoredNode>> {
+            Ok(self.nodes.get(&node_id).cloned())
+        }
+
+        fn list_children(&self, _parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+
+        fn list_outgoing_links(&self, _node_id: NodeId) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn list_incoming_links(&self, _node_id: NodeId) -> KernelResult<Vec<IncomingLinkRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn list_aliases(&self, _node_id: NodeId) -> KernelResult<Vec<AliasText>> {
+            Ok(Vec::new())
+        }
+
+        fn fetch_node_contents(
+            &self,
+            node_ids: &BTreeSet<NodeId>,
+        ) -> KernelResult<BTreeMap<NodeId, ContentLine>> {
+            Ok(node_ids
+                .iter()
+                .filter_map(|node_id| {
+                    self.nodes
+                        .get(node_id)
+                        .map(|node| (*node_id, node.content.clone()))
+                })
+                .collect())
+        }
+
+        fn lookup_candidates(&self, _key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
+            Ok(Vec::new())
+        }
+
+        fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
+            Ok(format!("path:{node_id}"))
+        }
+
+        fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+            Ok(None)
+        }
+
+        fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+            Ok(node_id == self.root_id)
+        }
+
+        fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+            Ok(self.nodes.get(&self.root_id).cloned().into_iter().collect())
+        }
+
+        fn find_root_node_by_content(
+            &self,
+            content: &ContentLine,
+        ) -> KernelResult<Option<StoredNode>> {
+            Ok(self
+                .nodes
+                .get(&self.root_id)
+                .filter(|node| node.content == *content)
+                .cloned())
+        }
+
+        fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+            Ok(self
+                .nodes
+                .values()
+                .filter(|node| node.id != self.root_id && node.content.as_str().contains(needle))
+                .cloned()
+                .collect())
+        }
+    }
+
+    impl WriteRepository for MalformedSearchRepository {
+        fn init_schema(&mut self) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_nodes_from_lines(
+            &mut self,
+            _placement: Placement,
+            _lines: &[ContentLine],
+            _aliases: &[AliasText],
+        ) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn create_nodes(
+            &mut self,
+            _placement: Placement,
+            _nodes: &[NewNodeRecord],
+        ) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn update_node_contents(
+            &mut self,
+            _updates: &[memoryroam_domain::NodeUpdateRecord],
+        ) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn move_node(&mut self, _node_id: NodeId, _placement: Placement) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn delete_node(
+            &mut self,
+            _node_id: NodeId,
+            _mode: memoryroam_domain::DeleteMode,
+        ) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn add_aliases(&mut self, _node_id: NodeId, _aliases: &[AliasText]) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn remove_alias(&mut self, _node_id: NodeId, _alias: &AliasText) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_root_node(&mut self, _node: &NewNodeRecord) -> KernelResult<NodeId> {
+            Ok(self.root_id)
+        }
+
+        fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+    }
+
+    #[test]
+    fn create_root_propagates_malformed_match_content() {
+        let root_id = NodeId::new(1).expect("valid test id");
+        let broken_id = NodeId::new(2).expect("valid test id");
+        let mut repository = MalformedSearchRepository {
+            nodes: BTreeMap::from([
+                (
+                    root_id,
+                    StoredNode {
+                        id: root_id,
+                        content: ContentLine::parse("Broken").expect("content should parse"),
+                        parent_id: None,
+                        first_child_id: None,
+                        last_child_id: None,
+                        prev_sibling_id: None,
+                        next_sibling_id: None,
+                    },
+                ),
+                (
+                    broken_id,
+                    StoredNode {
+                        id: broken_id,
+                        content: ContentLine::parse("Broken {{oops").expect("content should parse"),
+                        parent_id: None,
+                        first_child_id: None,
+                        last_child_id: None,
+                        prev_sibling_id: None,
+                        next_sibling_id: None,
+                    },
+                ),
+            ]),
+            root_id,
+        };
+
+        let error = create_root(&mut repository, "Broken")
+            .expect_err("malformed match content should be reported");
+        assert!(matches!(error, KernelError::Storage(_)));
     }
 
     #[test]

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -74,12 +74,12 @@ pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
     note_date: &str,
     raw_content: &str,
 ) -> KernelResult<NoteResult> {
+    let node = build_new_node(repository, raw_content)?;
     let note_node_id = match repository.find_daily_note(note_date)? {
         Some(record) => record.node_id,
         None => repository.create_daily_note_node(note_date)?,
     };
 
-    let node = build_new_node(repository, raw_content)?;
     let node_id = repository.create_nodes(
         memoryroam_domain::Placement::LastChildOf(note_node_id),
         &[node],
@@ -554,6 +554,20 @@ fn estimate_tokens(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use memoryroam_storage_sqlite::SqliteStore;
+    use memoryroam_write::init;
+    use tempfile::NamedTempFile;
+
+    fn store() -> SqliteStore {
+        let path = NamedTempFile::new()
+            .expect("temp file should exist")
+            .into_temp_path()
+            .keep()
+            .expect("temp path should be kept");
+        let mut store = SqliteStore::open_or_create(path).expect("store should open");
+        init(&mut store).expect("schema init should succeed");
+        store
+    }
 
     #[test]
     fn rewrite_text_fragments_updates_plain_text_without_touching_links() {
@@ -571,6 +585,21 @@ mod tests {
         assert_eq!(
             rewritten,
             "{{99::Software engineering}} and {{12::Software engineering}}"
+        );
+    }
+
+    #[test]
+    fn failed_note_does_not_leave_a_daily_note_behind() {
+        let mut store = store();
+
+        let error =
+            note_today(&mut store, "2026-04-11", "See {{Missing}}").expect_err("note should fail");
+        assert!(matches!(error, KernelError::LookupMiss { .. }));
+        assert!(
+            store
+                .list_daily_notes()
+                .expect("daily notes should load")
+                .is_empty()
         );
     }
 }

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -1,0 +1,576 @@
+#![forbid(unsafe_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![warn(rustdoc::private_intra_doc_links)]
+#![doc = include_str!("../README.md")]
+
+use memoryroam_domain::{
+    ContentFragment, ContentLine, IncomingLinkRecord, KernelError, KernelResult, NodeId, NodeLine,
+    ParsedLink, ReadRepository, StoredNode, canonicalize_content, parse_content,
+    render_storage_content,
+};
+use memoryroam_write::update_nodes;
+
+const DEFAULT_MATCH_LIMIT: usize = 50;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoteResult {
+    pub note_date: String,
+    pub node: NodeLine,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DayView {
+    pub note_date: String,
+    pub entries: Vec<NodeLine>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RootCreateResult {
+    pub root: NodeLine,
+    pub matches: Vec<NodeLine>,
+    pub hidden_match_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RootApplyResult {
+    pub updated_nodes: Vec<NodeLine>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BacklinkLine {
+    pub source: NodeLine,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChildContextLine {
+    pub node: NodeLine,
+    pub backlinks: Vec<BacklinkLine>,
+    pub hidden_backlink_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadContextView {
+    pub prev_hidden_count: usize,
+    pub prev_siblings: Vec<NodeLine>,
+    pub current: NodeLine,
+    pub backlinks: Vec<BacklinkLine>,
+    pub hidden_backlink_count: usize,
+    pub children: Vec<ChildContextLine>,
+    pub hidden_child_count: usize,
+    pub next_siblings: Vec<NodeLine>,
+    pub next_hidden_count: usize,
+}
+
+struct SiblingSelection {
+    prev_siblings: Vec<NodeLine>,
+    prev_hidden_count: usize,
+    next_siblings: Vec<NodeLine>,
+    next_hidden_count: usize,
+    used_tokens: usize,
+}
+
+pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
+    repository: &mut R,
+    note_date: &str,
+    raw_content: &str,
+) -> KernelResult<NoteResult> {
+    let note_node_id = match repository.find_daily_note(note_date)? {
+        Some(record) => record.node_id,
+        None => repository.create_daily_note_node(note_date)?,
+    };
+
+    let node = build_new_node(repository, raw_content)?;
+    let node_id = repository.create_nodes(
+        memoryroam_domain::Placement::LastChildOf(note_node_id),
+        &[node],
+    )?[0];
+    let created = repository
+        .get_node(node_id)?
+        .ok_or(KernelError::StorageCorruption(format!(
+            "missing created node {node_id}"
+        )))?;
+
+    Ok(NoteResult {
+        note_date: note_date.to_owned(),
+        node: render_node_line(repository, &created)?,
+    })
+}
+
+pub fn open_day<R: ReadRepository>(repository: &R, note_date: &str) -> KernelResult<DayView> {
+    let entries = match repository.find_daily_note(note_date)? {
+        Some(record) => repository
+            .list_children(Some(record.node_id))?
+            .iter()
+            .map(|node| render_node_line(repository, node))
+            .collect::<KernelResult<Vec<_>>>()?,
+        None => Vec::new(),
+    };
+
+    Ok(DayView {
+        note_date: note_date.to_owned(),
+        entries,
+    })
+}
+
+pub fn create_root<R: ReadRepository + memoryroam_domain::WriteRepository>(
+    repository: &mut R,
+    raw_content: &str,
+) -> KernelResult<RootCreateResult> {
+    let content =
+        ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
+    let root = match repository.find_root_node_by_content(&content)? {
+        Some(node) => node,
+        None => {
+            let node = build_new_node(repository, raw_content)?;
+            let node_id = repository.create_root_node(&node)?;
+            repository
+                .get_node(node_id)?
+                .ok_or(KernelError::StorageCorruption(format!(
+                    "missing created root node {node_id}"
+                )))?
+        }
+    };
+
+    let root_line = render_node_line(repository, &root)?;
+    let mut matches = repository
+        .search_text_matches(content.as_str())?
+        .into_iter()
+        .filter(|node| plain_text_contains(&node.content, content.as_str()).unwrap_or(false))
+        .collect::<Vec<_>>();
+    matches.sort_by(|left, right| compare_match_order(left, right, content.as_str()));
+
+    let hidden_match_count = matches.len().saturating_sub(DEFAULT_MATCH_LIMIT);
+    let matches = matches
+        .into_iter()
+        .take(DEFAULT_MATCH_LIMIT)
+        .map(|node| render_node_line(repository, &node))
+        .collect::<KernelResult<Vec<_>>>()?;
+
+    Ok(RootCreateResult {
+        root: root_line,
+        matches,
+        hidden_match_count,
+    })
+}
+
+pub fn apply_root_link<R: ReadRepository + memoryroam_domain::WriteRepository>(
+    repository: &mut R,
+    root_id: NodeId,
+    target_text: Option<&str>,
+    node_ids: &[NodeId],
+) -> KernelResult<RootApplyResult> {
+    let root = repository.get_node(root_id)?.ok_or(KernelError::NotFound {
+        entity: "node",
+        id: root_id,
+    })?;
+    if !repository.is_root_node(root_id)? {
+        return Err(KernelError::Constraint(format!(
+            "node {root_id} is not a root node"
+        )));
+    }
+
+    let target_text = target_text.unwrap_or(root.content.as_str());
+    if target_text.is_empty() || target_text.contains('\n') || target_text.contains('\r') {
+        return Err(KernelError::Input(String::from(
+            "root apply text must be a non-empty single line",
+        )));
+    }
+
+    let mut updates = Vec::with_capacity(node_ids.len());
+    for node_id in node_ids {
+        if repository.is_daily_note_node(*node_id)? {
+            return Err(KernelError::Constraint(String::from(
+                "daily note date nodes are immutable",
+            )));
+        }
+
+        let node = repository
+            .get_node(*node_id)?
+            .ok_or(KernelError::NotFound {
+                entity: "node",
+                id: *node_id,
+            })?;
+        let Some(rewritten) = rewrite_text_fragments(&node.content, target_text, root_id)? else {
+            return Err(KernelError::Constraint(format!(
+                "target text not found in node {node_id}"
+            )));
+        };
+        updates.push((*node_id, rewritten));
+    }
+
+    update_nodes(repository, &updates)?;
+
+    let updated_nodes = node_ids
+        .iter()
+        .map(|node_id| {
+            let node = repository
+                .get_node(*node_id)?
+                .ok_or(KernelError::StorageCorruption(format!(
+                    "missing updated node {node_id}"
+                )))?;
+            render_node_line(repository, &node)
+        })
+        .collect::<KernelResult<Vec<_>>>()?;
+
+    Ok(RootApplyResult { updated_nodes })
+}
+
+pub fn read_node_context<R: ReadRepository>(
+    repository: &R,
+    node_id: NodeId,
+    budget_target: usize,
+) -> KernelResult<ReadContextView> {
+    let node = repository.get_node(node_id)?.ok_or(KernelError::NotFound {
+        entity: "node",
+        id: node_id,
+    })?;
+    let current = render_node_line(repository, &node)?;
+    let current_tokens = estimate_tokens(current.rendered_content.as_str()) + 8;
+    let soft_limit = budget_target.saturating_add(300);
+    let mut used_tokens = current_tokens;
+
+    let (prev_candidates, next_candidates) = if repository.is_daily_note_node(node_id)? {
+        daily_note_neighbors(repository, node_id)?
+    } else if node.parent_id.is_some() {
+        (
+            collect_previous_siblings(repository, &node)?,
+            collect_next_siblings(repository, &node)?,
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    let sibling_selection = choose_siblings(
+        repository,
+        prev_candidates,
+        next_candidates,
+        used_tokens,
+        soft_limit,
+    )?;
+    used_tokens = sibling_selection.used_tokens;
+
+    let incoming_links = repository.list_incoming_links(node_id)?;
+    let (backlinks, hidden_backlink_count, used_after_backlinks) =
+        choose_backlinks(repository, &incoming_links, used_tokens, soft_limit)?;
+    used_tokens = used_after_backlinks;
+
+    let child_nodes = repository.list_children(Some(node_id))?;
+    let (children, hidden_child_count, _) =
+        choose_children(repository, &child_nodes, used_tokens, soft_limit)?;
+
+    Ok(ReadContextView {
+        prev_hidden_count: sibling_selection.prev_hidden_count,
+        prev_siblings: sibling_selection.prev_siblings,
+        current,
+        backlinks,
+        hidden_backlink_count,
+        children,
+        hidden_child_count,
+        next_siblings: sibling_selection.next_siblings,
+        next_hidden_count: sibling_selection.next_hidden_count,
+    })
+}
+
+fn build_new_node<R: ReadRepository>(
+    repository: &R,
+    raw_content: &str,
+) -> KernelResult<memoryroam_domain::NewNodeRecord> {
+    let content =
+        ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
+    let canonical = canonicalize_content(repository, &content)?;
+    Ok(memoryroam_domain::NewNodeRecord {
+        content: canonical.content,
+        lookup_key: canonical.lookup_key,
+        outgoing_links: canonical.outgoing_links,
+        aliases: Vec::new(),
+    })
+}
+
+fn render_node_line<R: ReadRepository>(
+    repository: &R,
+    node: &StoredNode,
+) -> KernelResult<NodeLine> {
+    Ok(NodeLine {
+        id: node.id,
+        rendered_content: render_storage_content(repository, &node.content)?,
+    })
+}
+
+fn compare_match_order(left: &StoredNode, right: &StoredNode, needle: &str) -> std::cmp::Ordering {
+    match_rank(left.content.as_str(), needle)
+        .cmp(&match_rank(right.content.as_str(), needle))
+        .then_with(|| left.id.value().cmp(&right.id.value()))
+}
+
+fn match_rank(content: &str, needle: &str) -> u8 {
+    if content == needle {
+        0
+    } else if content.starts_with(needle) {
+        1
+    } else {
+        2
+    }
+}
+
+fn plain_text_contains(content: &ContentLine, needle: &str) -> KernelResult<bool> {
+    let fragments =
+        parse_content(content).map_err(|error| KernelError::Storage(error.to_string()))?;
+    Ok(fragments.iter().any(|fragment| match fragment {
+        ContentFragment::Text(text) => text.contains(needle),
+        ContentFragment::Link(_) => false,
+    }))
+}
+
+fn rewrite_text_fragments(
+    content: &ContentLine,
+    needle: &str,
+    root_id: NodeId,
+) -> KernelResult<Option<String>> {
+    let fragments =
+        parse_content(content).map_err(|error| KernelError::Storage(error.to_string()))?;
+    let replacement = format!("{{{{{root_id}::{needle}}}}}");
+    let mut changed = false;
+    let mut rewritten = String::new();
+
+    for fragment in fragments {
+        match fragment {
+            ContentFragment::Text(text) => {
+                if text.contains(needle) {
+                    changed = true;
+                    rewritten.push_str(&text.replace(needle, replacement.as_str()));
+                } else {
+                    rewritten.push_str(&text);
+                }
+            }
+            ContentFragment::Link(link) => rewritten.push_str(link_to_storage(&link).as_str()),
+        }
+    }
+
+    Ok(changed.then_some(rewritten))
+}
+
+fn link_to_storage(link: &ParsedLink) -> String {
+    match link {
+        ParsedLink::ById(node_id) | ParsedLink::ByNumericToken(node_id) => {
+            format!("{{{{{node_id}}}}}")
+        }
+        ParsedLink::ByLookup(lookup) => format!("{{{{{lookup}}}}}"),
+        ParsedLink::ByIdWithLabel(node_id, label) => {
+            format!("{{{{{node_id}::{}}}}}", label.as_str())
+        }
+    }
+}
+
+fn collect_previous_siblings<R: ReadRepository>(
+    repository: &R,
+    node: &StoredNode,
+) -> KernelResult<Vec<StoredNode>> {
+    let mut siblings = Vec::new();
+    let mut current = node.prev_sibling_id;
+    while let Some(node_id) = current {
+        let sibling = repository
+            .get_node(node_id)?
+            .ok_or(KernelError::StorageCorruption(format!(
+                "missing sibling node {node_id}"
+            )))?;
+        current = sibling.prev_sibling_id;
+        siblings.push(sibling);
+    }
+    Ok(siblings)
+}
+
+fn collect_next_siblings<R: ReadRepository>(
+    repository: &R,
+    node: &StoredNode,
+) -> KernelResult<Vec<StoredNode>> {
+    let mut siblings = Vec::new();
+    let mut current = node.next_sibling_id;
+    while let Some(node_id) = current {
+        let sibling = repository
+            .get_node(node_id)?
+            .ok_or(KernelError::StorageCorruption(format!(
+                "missing sibling node {node_id}"
+            )))?;
+        current = sibling.next_sibling_id;
+        siblings.push(sibling);
+    }
+    Ok(siblings)
+}
+
+fn daily_note_neighbors<R: ReadRepository>(
+    repository: &R,
+    node_id: NodeId,
+) -> KernelResult<(Vec<StoredNode>, Vec<StoredNode>)> {
+    let daily_notes = repository.list_daily_notes()?;
+    let current_index = daily_notes
+        .iter()
+        .position(|record| record.node_id == node_id)
+        .ok_or(KernelError::StorageCorruption(format!(
+            "missing daily note membership for node {node_id}"
+        )))?;
+
+    let previous = daily_notes[..current_index]
+        .iter()
+        .rev()
+        .map(|record| {
+            repository
+                .get_node(record.node_id)?
+                .ok_or(KernelError::StorageCorruption(format!(
+                    "missing daily note node {}",
+                    record.node_id
+                )))
+        })
+        .collect::<KernelResult<Vec<_>>>()?;
+    let next = daily_notes[current_index + 1..]
+        .iter()
+        .map(|record| {
+            repository
+                .get_node(record.node_id)?
+                .ok_or(KernelError::StorageCorruption(format!(
+                    "missing daily note node {}",
+                    record.node_id
+                )))
+        })
+        .collect::<KernelResult<Vec<_>>>()?;
+
+    Ok((previous, next))
+}
+
+fn choose_siblings<R: ReadRepository>(
+    repository: &R,
+    prev_candidates: Vec<StoredNode>,
+    next_candidates: Vec<StoredNode>,
+    mut used_tokens: usize,
+    soft_limit: usize,
+) -> KernelResult<SiblingSelection> {
+    let mut chosen_prev = Vec::new();
+    let mut chosen_next = Vec::new();
+    let max_len = prev_candidates.len().max(next_candidates.len());
+
+    for index in 0..max_len {
+        if let Some(node) = prev_candidates.get(index) {
+            let line = render_node_line(repository, node)?;
+            let line_tokens = estimate_tokens(line.rendered_content.as_str()) + 8;
+            if used_tokens + line_tokens <= soft_limit {
+                used_tokens += line_tokens;
+                chosen_prev.push(line);
+            }
+        }
+        if let Some(node) = next_candidates.get(index) {
+            let line = render_node_line(repository, node)?;
+            let line_tokens = estimate_tokens(line.rendered_content.as_str()) + 8;
+            if used_tokens + line_tokens <= soft_limit {
+                used_tokens += line_tokens;
+                chosen_next.push(line);
+            }
+        }
+    }
+
+    chosen_prev.reverse();
+    let prev_hidden_count = prev_candidates.len().saturating_sub(chosen_prev.len());
+    let next_hidden_count = next_candidates.len().saturating_sub(chosen_next.len());
+
+    Ok(SiblingSelection {
+        prev_siblings: chosen_prev,
+        prev_hidden_count,
+        next_siblings: chosen_next,
+        next_hidden_count,
+        used_tokens,
+    })
+}
+
+fn choose_backlinks<R: ReadRepository>(
+    repository: &R,
+    incoming_links: &[IncomingLinkRecord],
+    mut used_tokens: usize,
+    soft_limit: usize,
+) -> KernelResult<(Vec<BacklinkLine>, usize, usize)> {
+    let mut backlinks = Vec::new();
+    for incoming in incoming_links {
+        let line = BacklinkLine {
+            source: NodeLine {
+                id: incoming.source_node_id,
+                rendered_content: render_storage_content(repository, &incoming.source_content)?,
+            },
+        };
+        let line_tokens = estimate_tokens(line.source.rendered_content.as_str()) + 8;
+        if used_tokens + line_tokens > soft_limit {
+            break;
+        }
+        used_tokens += line_tokens;
+        backlinks.push(line);
+    }
+
+    let hidden = incoming_links.len().saturating_sub(backlinks.len());
+    Ok((backlinks, hidden, used_tokens))
+}
+
+fn choose_children<R: ReadRepository>(
+    repository: &R,
+    child_nodes: &[StoredNode],
+    mut used_tokens: usize,
+    soft_limit: usize,
+) -> KernelResult<(Vec<ChildContextLine>, usize, usize)> {
+    let mut children = Vec::new();
+    for child in child_nodes {
+        let child_line = render_node_line(repository, child)?;
+        let child_tokens = estimate_tokens(child_line.rendered_content.as_str()) + 8;
+        if used_tokens + child_tokens > soft_limit {
+            break;
+        }
+        used_tokens += child_tokens;
+
+        let incoming_links = repository.list_incoming_links(child.id)?;
+        let (backlinks, hidden_backlink_count, used_after_backlinks) =
+            choose_backlinks(repository, &incoming_links, used_tokens, soft_limit)?;
+        used_tokens = used_after_backlinks;
+
+        children.push(ChildContextLine {
+            node: child_line,
+            backlinks,
+            hidden_backlink_count,
+        });
+    }
+
+    let hidden = child_nodes.len().saturating_sub(children.len());
+    Ok((children, hidden, used_tokens))
+}
+
+fn estimate_tokens(text: &str) -> usize {
+    let mut ascii_count = 0usize;
+    let mut non_ascii_count = 0usize;
+
+    for character in text.chars() {
+        if character.is_ascii() {
+            ascii_count += 1;
+        } else {
+            non_ascii_count += 1;
+        }
+    }
+
+    8 + non_ascii_count + ascii_count.div_ceil(3)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrite_text_fragments_updates_plain_text_without_touching_links() {
+        let content = ContentLine::parse("Software engineering and {{12::Software engineering}}")
+            .expect("content should parse");
+
+        let rewritten = rewrite_text_fragments(
+            &content,
+            "Software engineering",
+            NodeId::new(99).expect("valid test id"),
+        )
+        .expect("rewrite should succeed")
+        .expect("rewrite should change text");
+
+        assert_eq!(
+            rewritten,
+            "{{99::Software engineering}} and {{12::Software engineering}}"
+        );
+    }
+}

--- a/crates/memoryroam-application/src/lib.rs
+++ b/crates/memoryroam-application/src/lib.rs
@@ -77,7 +77,16 @@ pub fn note_today<R: ReadRepository + memoryroam_domain::WriteRepository>(
     let node = build_new_node(repository, raw_content)?;
     let note_node_id = match repository.find_daily_note(note_date)? {
         Some(record) => record.node_id,
-        None => repository.create_daily_note_node(note_date)?,
+        None => match repository.create_daily_note_node(note_date) {
+            Ok(node_id) => node_id,
+            Err(KernelError::Constraint(_)) => repository
+                .find_daily_note(note_date)?
+                .map(|record| record.node_id)
+                .ok_or(KernelError::Constraint(format!(
+                    "daily note {note_date} could not be created"
+                )))?,
+            Err(error) => return Err(error),
+        },
     };
 
     let node_id = repository.create_nodes(
@@ -554,6 +563,12 @@ fn estimate_tokens(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use memoryroam_domain::{
+        AliasText, DailyNoteRecord, IncomingLinkRecord, LookupCandidate, LookupKey, NewNodeRecord,
+        Placement, StoredNode, WriteRepository,
+    };
     use memoryroam_storage_sqlite::SqliteStore;
     use memoryroam_write::init;
     use tempfile::NamedTempFile;
@@ -601,5 +616,214 @@ mod tests {
                 .expect("daily notes should load")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn create_root_reuses_existing_root_by_normalized_lookup_key() {
+        let mut store = store();
+
+        let first = create_root(&mut store, "Topic").expect("first root should be created");
+        let second =
+            create_root(&mut store, " Topic ").expect("second root should reuse the first root");
+
+        assert_eq!(first.root.id, second.root.id);
+    }
+
+    #[derive(Default)]
+    struct RaceRepository {
+        nodes: BTreeMap<NodeId, StoredNode>,
+        daily_note: Option<DailyNoteRecord>,
+        next_id: i64,
+        create_daily_note_attempts: usize,
+    }
+
+    impl ReadRepository for RaceRepository {
+        fn get_node(&self, node_id: NodeId) -> KernelResult<Option<StoredNode>> {
+            Ok(self.nodes.get(&node_id).cloned())
+        }
+
+        fn list_children(&self, _parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+
+        fn list_outgoing_links(&self, _node_id: NodeId) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn list_incoming_links(&self, _node_id: NodeId) -> KernelResult<Vec<IncomingLinkRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn list_aliases(&self, _node_id: NodeId) -> KernelResult<Vec<AliasText>> {
+            Ok(Vec::new())
+        }
+
+        fn fetch_node_contents(
+            &self,
+            node_ids: &BTreeSet<NodeId>,
+        ) -> KernelResult<BTreeMap<NodeId, ContentLine>> {
+            Ok(node_ids
+                .iter()
+                .filter_map(|node_id| {
+                    self.nodes
+                        .get(node_id)
+                        .map(|node| (*node_id, node.content.clone()))
+                })
+                .collect())
+        }
+
+        fn lookup_candidates(&self, _key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
+            Ok(Vec::new())
+        }
+
+        fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
+            Ok(format!("path:{node_id}"))
+        }
+
+        fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+            Ok(self.daily_note.clone())
+        }
+
+        fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+            Ok(self.daily_note.clone().into_iter().collect())
+        }
+
+        fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+
+        fn find_root_node_by_content(
+            &self,
+            _content: &ContentLine,
+        ) -> KernelResult<Option<StoredNode>> {
+            Ok(None)
+        }
+
+        fn search_text_matches(&self, _needle: &str) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl WriteRepository for RaceRepository {
+        fn init_schema(&mut self) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_nodes_from_lines(
+            &mut self,
+            _placement: Placement,
+            _lines: &[ContentLine],
+            _aliases: &[AliasText],
+        ) -> KernelResult<Vec<NodeId>> {
+            Ok(Vec::new())
+        }
+
+        fn create_nodes(
+            &mut self,
+            placement: Placement,
+            nodes: &[NewNodeRecord],
+        ) -> KernelResult<Vec<NodeId>> {
+            assert_eq!(nodes.len(), 1);
+            let parent_id = match placement {
+                Placement::LastChildOf(parent_id) => parent_id,
+                other => panic!("unexpected placement {other:?}"),
+            };
+            self.next_id += 1;
+            let node_id = NodeId::new(self.next_id).expect("valid test id");
+            self.nodes.insert(
+                node_id,
+                StoredNode {
+                    id: node_id,
+                    content: nodes[0].content.clone(),
+                    parent_id: Some(parent_id),
+                    first_child_id: None,
+                    last_child_id: None,
+                    prev_sibling_id: None,
+                    next_sibling_id: None,
+                },
+            );
+            Ok(vec![node_id])
+        }
+
+        fn update_node_contents(
+            &mut self,
+            _updates: &[memoryroam_domain::NodeUpdateRecord],
+        ) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn move_node(&mut self, _node_id: NodeId, _placement: Placement) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn delete_node(
+            &mut self,
+            _node_id: NodeId,
+            _mode: memoryroam_domain::DeleteMode,
+        ) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn add_aliases(&mut self, _node_id: NodeId, _aliases: &[AliasText]) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn remove_alias(&mut self, _node_id: NodeId, _alias: &AliasText) -> KernelResult<()> {
+            Ok(())
+        }
+
+        fn create_root_node(&mut self, _node: &NewNodeRecord) -> KernelResult<NodeId> {
+            Err(KernelError::Storage(String::from("unused in test")))
+        }
+
+        fn create_daily_note_node(&mut self, note_date: &str) -> KernelResult<NodeId> {
+            self.create_daily_note_attempts += 1;
+            if self.create_daily_note_attempts == 1 {
+                let node_id = NodeId::new(1).expect("valid test id");
+                self.nodes.insert(
+                    node_id,
+                    StoredNode {
+                        id: node_id,
+                        content: ContentLine::parse(note_date).expect("content should parse"),
+                        parent_id: None,
+                        first_child_id: None,
+                        last_child_id: None,
+                        prev_sibling_id: None,
+                        next_sibling_id: None,
+                    },
+                );
+                self.daily_note = Some(DailyNoteRecord {
+                    note_date: note_date.to_owned(),
+                    node_id,
+                });
+                return Err(KernelError::Constraint(String::from(
+                    "unique constraint failed",
+                )));
+            }
+
+            panic!("note_today should retry by re-reading the daily note");
+        }
+    }
+
+    #[test]
+    fn note_today_reuses_daily_note_after_conflicting_first_create() {
+        let mut repository = RaceRepository {
+            next_id: 1,
+            ..RaceRepository::default()
+        };
+
+        let result = note_today(&mut repository, "2026-04-11", "Captured note")
+            .expect("note should succeed after re-reading the daily note");
+
+        assert_eq!(result.note_date, "2026-04-11");
+        assert_eq!(repository.create_daily_note_attempts, 1);
     }
 }

--- a/crates/memoryroam-cli/Cargo.toml
+++ b/crates/memoryroam-cli/Cargo.toml
@@ -11,9 +11,10 @@ name = "memoryroam"
 path = "src/main.rs"
 
 [dependencies]
+chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
 clap = { version = "4.5.48", features = ["derive"] }
+memoryroam-application = { path = "../memoryroam-application" }
 memoryroam-domain = { path = "../memoryroam-domain" }
-memoryroam-read = { path = "../memoryroam-read" }
 memoryroam-storage-sqlite = { path = "../memoryroam-storage-sqlite" }
 memoryroam-write = { path = "../memoryroam-write" }
 

--- a/crates/memoryroam-cli/README.md
+++ b/crates/memoryroam-cli/README.md
@@ -1,6 +1,6 @@
 # memoryroam-cli
 
-`memoryroam-cli` is the executable package that exposes the MemoryRoam note kernel as a plain-text command-line interface.
+`memoryroam-cli` is the executable package that exposes MemoryRoam through note-taking oriented commands.
 
 ## Install
 
@@ -50,46 +50,40 @@ Initialize a database:
 cargo run --bin memoryroam -- --db notes.sqlite3 init
 ```
 
-Create one or more nodes:
+Capture a note into today's daily note:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 create --content "Topic"
-cargo run --bin memoryroam -- --db notes.sqlite3 create --content $'Topic\nSee {{Topic}}'
+cargo run --bin memoryroam -- --db notes.sqlite3 note "Draft the interaction design"
 ```
 
-Read a node:
+Open today's daily note:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 read --id 1
+cargo run --bin memoryroam -- --db notes.sqlite3 day
 ```
 
-List nodes:
+Open a specific daily note:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 list --top-level
-cargo run --bin memoryroam -- --db notes.sqlite3 list --children-of 1
+cargo run --bin memoryroam -- --db notes.sqlite3 day 2026-04-11
 ```
 
-Update content:
+Read one node with structural context markers:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 update --id 1 --content "Updated"
-printf 'Updated from stdin\n' | cargo run --bin memoryroam -- --db notes.sqlite3 update --id 1
+cargo run --bin memoryroam -- --db notes.sqlite3 read 42
 ```
 
-Move or delete nodes:
+Create or reuse a root node and list candidate notes:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 move --id 3 --before 1
-cargo run --bin memoryroam -- --db notes.sqlite3 delete --id 3 --cascade
+cargo run --bin memoryroam -- --db notes.sqlite3 root create "Software engineering"
 ```
 
-Manage aliases:
+Rewrite selected notes to one root link:
 
 ```bash
-cargo run --bin memoryroam -- --db notes.sqlite3 alias add --id 1 --text topic
-cargo run --bin memoryroam -- --db notes.sqlite3 alias list --id 1
-cargo run --bin memoryroam -- --db notes.sqlite3 alias remove --id 1 --text topic
+cargo run --bin memoryroam -- --db notes.sqlite3 root apply 12 --node 41 --node 42
 ```
 
 ## Operational Model
@@ -97,3 +91,6 @@ cargo run --bin memoryroam -- --db notes.sqlite3 alias remove --id 1 --text topi
 - Every command runs as a short-lived process.
 - Commands open the SQLite file, perform one operation, print plain text, and exit.
 - Only `init` creates the database file when it does not exist.
+- `note` always writes into today's daily note and never accepts an explicit target date.
+- `day` only reads; opening an empty date does not create anything.
+- `read` prints marker-based structural context rather than field-labeled diagnostics.

--- a/crates/memoryroam-cli/README.md
+++ b/crates/memoryroam-cli/README.md
@@ -50,6 +50,38 @@ Show help:
 cargo run --bin memoryroam -- --help
 ```
 
+Quick start with an installed binary:
+
+```bash
+memoryroam --db notes.sqlite3 init
+memoryroam --db notes.sqlite3 note "Check the scope of issue 7"
+memoryroam --db notes.sqlite3 note "Design the root relink workflow"
+memoryroam --db notes.sqlite3 day
+memoryroam --db notes.sqlite3 read 2
+```
+
+The sample IDs in this sequence assume a brand-new database file.
+
+Equivalent quick start from a source checkout:
+
+```bash
+cargo run --bin memoryroam -- --db notes.sqlite3 init
+cargo run --bin memoryroam -- --db notes.sqlite3 note "Check the scope of issue 7"
+cargo run --bin memoryroam -- --db notes.sqlite3 note "Design the root relink workflow"
+cargo run --bin memoryroam -- --db notes.sqlite3 day
+cargo run --bin memoryroam -- --db notes.sqlite3 read 2
+```
+
+Root-link workflow on a fresh database:
+
+```bash
+memoryroam --db notes.sqlite3 init
+memoryroam --db notes.sqlite3 note "Software engineering is a branch of engineering"
+memoryroam --db notes.sqlite3 note "Software engineering emerged in the 1960s"
+memoryroam --db notes.sqlite3 root create "Software engineering"
+memoryroam --db notes.sqlite3 root apply 4 --node 2 --node 3
+```
+
 Initialize a database:
 
 ```bash

--- a/crates/memoryroam-cli/README.md
+++ b/crates/memoryroam-cli/README.md
@@ -5,7 +5,6 @@
 ## Install
 
 Published builds are distributed through GitHub Releases.
-The repository does not have a tagged release yet, so the release-based install commands below will start working after the first `vX.Y.Z` release is published.
 
 Install the latest published release on macOS or glibc-based Linux:
 
@@ -23,11 +22,18 @@ If you prefer a manual install, download a platform archive from the [Releases](
 Each archive contains the `memoryroam` executable.
 musl-based Linux distributions such as Alpine are not covered by the current release artifacts.
 
-Until the first tagged release exists, use a source checkout:
+To install a specific release such as `v0.1.0`, replace `latest` with the tag name:
 
 ```bash
-cargo build --bin memoryroam
-./target/debug/memoryroam --help
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/JiaJunDeng5930/MemoryRoamCLI/releases/download/v0.1.0/memoryroam-cli-installer.sh | sh
+```
+
+The installers place `memoryroam` into `CARGO_HOME/bin`.
+If `CARGO_HOME` is not set, the default location is `~/.cargo/bin`.
+Ensure that directory is present in `PATH`, then verify the installation:
+
+```bash
+memoryroam --help
 ```
 
 ## Build

--- a/crates/memoryroam-cli/src/main.rs
+++ b/crates/memoryroam-cli/src/main.rs
@@ -1,5 +1,5 @@
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use chrono::Local;
@@ -98,7 +98,7 @@ fn run(cli: Cli) -> Result<(), KernelError> {
             let store = SqliteStore::open_existing(&cli.db)?;
             let note_date = command.note_date.unwrap_or_else(today_date);
             let result = open_day(&store, &note_date)?;
-            print_day_view(&result);
+            print_day_view(&result, &cli.db);
         }
         Command::Read(command) => {
             let store = SqliteStore::open_existing(&cli.db)?;
@@ -179,13 +179,16 @@ fn print_note_result(result: &NoteResult) {
     println!("+[{}] {}", result.node.id, result.node.rendered_content);
 }
 
-fn print_day_view(view: &DayView) {
+fn print_day_view(view: &DayView, database_path: &Path) {
     println!("{}", view.note_date);
     println!();
     if view.entries.is_empty() {
         println!("empty");
         if view.note_date == today_date() {
-            println!("use: memoryroam note \"...\"");
+            println!(
+                "use: memoryroam --db {} note \"...\"",
+                database_path.display()
+            );
         }
         return;
     }

--- a/crates/memoryroam-cli/src/main.rs
+++ b/crates/memoryroam-cli/src/main.rs
@@ -33,6 +33,7 @@ enum Command {
 
 #[derive(Debug, Args)]
 struct NoteCommand {
+    #[arg(allow_hyphen_values = true)]
     content: Option<String>,
 }
 
@@ -55,11 +56,13 @@ struct RootCommand {
 #[derive(Debug, Subcommand)]
 enum RootSubcommand {
     Create {
+        #[arg(allow_hyphen_values = true)]
         content: Option<String>,
     },
     Apply {
         root_id: i64,
         #[arg(long)]
+        #[arg(allow_hyphen_values = true)]
         text: Option<String>,
         #[arg(long)]
         node: Vec<i64>,

--- a/crates/memoryroam-cli/src/main.rs
+++ b/crates/memoryroam-cli/src/main.rs
@@ -184,7 +184,9 @@ fn print_day_view(view: &DayView) {
     println!();
     if view.entries.is_empty() {
         println!("empty");
-        println!("use: memoryroam note \"...\"");
+        if view.note_date == today_date() {
+            println!("use: memoryroam note \"...\"");
+        }
         return;
     }
 

--- a/crates/memoryroam-cli/src/main.rs
+++ b/crates/memoryroam-cli/src/main.rs
@@ -187,7 +187,7 @@ fn print_day_view(view: &DayView, database_path: &Path) {
         if view.note_date == today_date() {
             println!(
                 "use: memoryroam --db {} note \"...\"",
-                database_path.display()
+                shell_quote_path(database_path)
             );
         }
         return;
@@ -258,4 +258,10 @@ fn print_read_context(view: &ReadContextView) {
     if view.next_hidden_count > 0 {
         println!("...next {} sibling hiding...", view.next_hidden_count);
     }
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    let raw = path.display().to_string();
+    let escaped = raw.replace('\'', "'\"'\"'");
+    format!("'{escaped}'")
 }

--- a/crates/memoryroam-cli/src/main.rs
+++ b/crates/memoryroam-cli/src/main.rs
@@ -185,10 +185,8 @@ fn print_day_view(view: &DayView, database_path: &Path) {
     if view.entries.is_empty() {
         println!("empty");
         if view.note_date == today_date() {
-            println!(
-                "use: memoryroam --db {} note \"...\"",
-                shell_quote_path(database_path)
-            );
+            println!("use: memoryroam --db <database-path> note \"...\"");
+            println!("database path: {}", database_path.display());
         }
         return;
     }
@@ -258,10 +256,4 @@ fn print_read_context(view: &ReadContextView) {
     if view.next_hidden_count > 0 {
         println!("...next {} sibling hiding...", view.next_hidden_count);
     }
-}
-
-fn shell_quote_path(path: &Path) -> String {
-    let raw = path.display().to_string();
-    let escaped = raw.replace('\'', "'\"'\"'");
-    format!("'{escaped}'")
 }

--- a/crates/memoryroam-cli/src/main.rs
+++ b/crates/memoryroam-cli/src/main.rs
@@ -2,17 +2,19 @@ use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use clap::{ArgGroup, Args, Parser, Subcommand};
-use memoryroam_domain::{DeleteMode, KernelError, NodeId, Placement, ReadNodeView};
-use memoryroam_read::{list_aliases, list_children, list_top_level, read_node};
-use memoryroam_storage_sqlite::SqliteStore;
-use memoryroam_write::{
-    add_aliases, create_nodes, delete_node, init, move_node, remove_alias, update_node,
+use chrono::Local;
+use clap::{Args, Parser, Subcommand};
+use memoryroam_application::{
+    DayView, NoteResult, ReadContextView, RootApplyResult, RootCreateResult, apply_root_link,
+    create_root, note_today, open_day, read_node_context,
 };
+use memoryroam_domain::{KernelError, NodeId};
+use memoryroam_storage_sqlite::SqliteStore;
+use memoryroam_write::init;
 
 #[derive(Debug, Parser)]
 #[command(name = "memoryroam")]
-#[command(about = "Structured note kernel CLI")]
+#[command(about = "Note-taking oriented MemoryRoam CLI")]
 struct Cli {
     #[arg(long, global = true, default_value = "memoryroam.sqlite3")]
     db: PathBuf,
@@ -23,158 +25,45 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     Init,
-    Create(CreateCommand),
-    Update(UpdateCommand),
-    Read(NodeSelector),
-    List(ListCommand),
-    Move(MoveCommand),
-    Delete(DeleteCommand),
-    Alias(AliasCommand),
+    Note(NoteCommand),
+    Day(DayCommand),
+    Read(ReadCommand),
+    Root(RootCommand),
 }
 
 #[derive(Debug, Args)]
-struct NodeSelector {
-    #[arg(long)]
-    id: i64,
-}
-
-#[derive(Debug, Args)]
-#[command(group(
-    ArgGroup::new("placement")
-        .args([
-            "top_level_first",
-            "top_level_last",
-            "before",
-            "after",
-            "first_child_of",
-            "last_child_of"
-        ])
-        .multiple(false)
-))]
-struct PlacementArgs {
-    #[arg(long)]
-    top_level_first: bool,
-    #[arg(long)]
-    top_level_last: bool,
-    #[arg(long)]
-    before: Option<i64>,
-    #[arg(long)]
-    after: Option<i64>,
-    #[arg(long)]
-    first_child_of: Option<i64>,
-    #[arg(long)]
-    last_child_of: Option<i64>,
-}
-
-impl PlacementArgs {
-    fn into_placement(self, default: Option<Placement>) -> Result<Placement, KernelError> {
-        if self.top_level_first {
-            return Ok(Placement::TopLevelFirst);
-        }
-        if self.top_level_last {
-            return Ok(Placement::TopLevelLast);
-        }
-        if let Some(id) = self.before {
-            return Ok(Placement::Before(parse_node_id(id)?));
-        }
-        if let Some(id) = self.after {
-            return Ok(Placement::After(parse_node_id(id)?));
-        }
-        if let Some(id) = self.first_child_of {
-            return Ok(Placement::FirstChildOf(parse_node_id(id)?));
-        }
-        if let Some(id) = self.last_child_of {
-            return Ok(Placement::LastChildOf(parse_node_id(id)?));
-        }
-
-        default.ok_or(KernelError::Input(String::from(
-            "a placement option is required",
-        )))
-    }
-}
-
-#[derive(Debug, Args)]
-struct CreateCommand {
-    #[arg(long)]
-    content: Option<String>,
-    #[arg(long)]
-    alias: Vec<String>,
-    #[command(flatten)]
-    placement: PlacementArgs,
-}
-
-#[derive(Debug, Args)]
-struct UpdateCommand {
-    #[arg(long)]
-    id: i64,
-    #[arg(long)]
+struct NoteCommand {
     content: Option<String>,
 }
 
 #[derive(Debug, Args)]
-struct ListCommand {
-    #[arg(long)]
-    top_level: bool,
-    #[arg(long)]
-    children_of: Option<i64>,
+struct DayCommand {
+    note_date: Option<String>,
 }
 
 #[derive(Debug, Args)]
-struct MoveCommand {
-    #[arg(long)]
+struct ReadCommand {
     id: i64,
-    #[command(flatten)]
-    placement: PlacementArgs,
 }
 
 #[derive(Debug, Args)]
-#[command(group(
-    ArgGroup::new("delete_mode")
-        .args([
-            "cascade",
-            "top_level_first",
-            "top_level_last",
-            "before",
-            "after",
-            "first_child_of",
-            "last_child_of"
-        ])
-        .multiple(false)
-        .required(true)
-))]
-struct DeleteCommand {
-    #[arg(long)]
-    id: i64,
-    #[arg(long)]
-    cascade: bool,
-    #[command(flatten)]
-    placement: PlacementArgs,
+struct RootCommand {
+    #[command(subcommand)]
+    command: RootSubcommand,
 }
 
 #[derive(Debug, Subcommand)]
-enum AliasSubcommand {
-    Add {
-        #[arg(long)]
-        id: i64,
-        #[arg(long)]
-        text: Vec<String>,
+enum RootSubcommand {
+    Create {
+        content: Option<String>,
     },
-    Remove {
+    Apply {
+        root_id: i64,
         #[arg(long)]
-        id: i64,
+        text: Option<String>,
         #[arg(long)]
-        text: String,
+        node: Vec<i64>,
     },
-    List {
-        #[arg(long)]
-        id: i64,
-    },
-}
-
-#[derive(Debug, Args)]
-struct AliasCommand {
-    #[command(subcommand)]
-    command: AliasSubcommand,
 }
 
 fn main() -> ExitCode {
@@ -195,87 +84,62 @@ fn run(cli: Cli) -> Result<(), KernelError> {
             init(&mut store)?;
             println!("initialized {}", store.database_path().display());
         }
-        Command::Create(command) => {
-            let mut store = SqliteStore::open_existing(&cli.db)?;
-            let placement = command
-                .placement
-                .into_placement(Some(Placement::TopLevelLast))?;
-            let input = read_content_input(command.content)?;
-            let node_ids = create_nodes(&mut store, &input, &command.alias, placement)?;
-            println!("created:");
-            for node_id in node_ids {
-                println!("- {node_id}");
-            }
-        }
-        Command::Update(command) => {
+        Command::Note(command) => {
             let mut store = SqliteStore::open_existing(&cli.db)?;
             let content = read_content_input(command.content)?;
-            update_node(&mut store, parse_node_id(command.id)?, &content)?;
-            println!("updated {}", command.id);
+            let note_date = today_date();
+            let result = note_today(&mut store, &note_date, &content)?;
+            print_note_result(&result);
+        }
+        Command::Day(command) => {
+            let store = SqliteStore::open_existing(&cli.db)?;
+            let note_date = command.note_date.unwrap_or_else(today_date);
+            let result = open_day(&store, &note_date)?;
+            print_day_view(&result);
         }
         Command::Read(command) => {
             let store = SqliteStore::open_existing(&cli.db)?;
-            let view = read_node(&store, parse_node_id(command.id)?)?;
-            print_read_view(&view);
+            let result = read_node_context(&store, parse_node_id(command.id)?, 5500)?;
+            print_read_context(&result);
         }
-        Command::List(command) => {
-            let store = SqliteStore::open_existing(&cli.db)?;
-            if command.top_level == command.children_of.is_some() {
-                return Err(KernelError::Input(String::from(
-                    "choose either --top-level or --children-of",
-                )));
-            }
-
-            let entries = if command.top_level {
-                list_top_level(&store)?
-            } else {
-                list_children(
-                    &store,
-                    parse_node_id(command.children_of.expect("children_of checked above"))?,
-                )?
-            };
-
-            for entry in entries {
-                println!("{}\t{}", entry.id, entry.rendered_content);
-            }
-        }
-        Command::Move(command) => {
-            let mut store = SqliteStore::open_existing(&cli.db)?;
-            let placement = command.placement.into_placement(None)?;
-            move_node(&mut store, parse_node_id(command.id)?, placement)?;
-            println!("moved {}", command.id);
-        }
-        Command::Delete(command) => {
-            let mut store = SqliteStore::open_existing(&cli.db)?;
-            let mode = if command.cascade {
-                DeleteMode::Cascade
-            } else {
-                DeleteMode::Reparent(command.placement.into_placement(None)?)
-            };
-            delete_node(&mut store, parse_node_id(command.id)?, mode)?;
-            println!("deleted {}", command.id);
-        }
-        Command::Alias(alias_command) => match alias_command.command {
-            AliasSubcommand::Add { id, text } => {
+        Command::Root(root_command) => match root_command.command {
+            RootSubcommand::Create { content } => {
                 let mut store = SqliteStore::open_existing(&cli.db)?;
-                add_aliases(&mut store, parse_node_id(id)?, &text)?;
-                println!("alias-added {}", id);
+                let content = read_content_input(content)?;
+                let result = create_root(&mut store, &content)?;
+                print_root_create_result(&result);
             }
-            AliasSubcommand::Remove { id, text } => {
+            RootSubcommand::Apply {
+                root_id,
+                text,
+                node,
+            } => {
                 let mut store = SqliteStore::open_existing(&cli.db)?;
-                remove_alias(&mut store, parse_node_id(id)?, &text)?;
-                println!("alias-removed {}", id);
-            }
-            AliasSubcommand::List { id } => {
-                let store = SqliteStore::open_existing(&cli.db)?;
-                for alias in list_aliases(&store, parse_node_id(id)?)? {
-                    println!("{}", alias.as_str());
+                if node.is_empty() {
+                    return Err(KernelError::Input(String::from(
+                        "root apply requires at least one --node",
+                    )));
                 }
+                let node_ids = node
+                    .into_iter()
+                    .map(parse_node_id)
+                    .collect::<Result<Vec<_>, _>>()?;
+                let result = apply_root_link(
+                    &mut store,
+                    parse_node_id(root_id)?,
+                    text.as_deref(),
+                    &node_ids,
+                )?;
+                print_root_apply_result(&result);
             }
         },
     }
 
     Ok(())
+}
+
+fn today_date() -> String {
+    Local::now().date_naive().format("%F").to_string()
 }
 
 fn parse_node_id(value: i64) -> Result<NodeId, KernelError> {
@@ -293,7 +157,7 @@ fn read_content_input(explicit_content: Option<String>) -> Result<String, Kernel
         .map_err(|error| KernelError::Input(error.to_string()))?;
     if buffer.is_empty() {
         return Err(KernelError::Input(String::from(
-            "content must be provided via --content or stdin",
+            "content must be provided as an argument or via stdin",
         )));
     }
 
@@ -307,53 +171,83 @@ fn read_content_input(explicit_content: Option<String>) -> Result<String, Kernel
     Ok(buffer)
 }
 
-fn print_read_view(view: &ReadNodeView) {
-    println!("Node: {}", view.node.id);
-    println!("Content: {}", view.node.rendered_content);
-    println!(
-        "Parent: {}",
-        view.parent
-            .as_ref()
-            .map(format_node_line)
-            .unwrap_or_else(|| String::from("none"))
-    );
-    println!(
-        "Prev sibling: {}",
-        view.prev_sibling
-            .as_ref()
-            .map(format_node_line)
-            .unwrap_or_else(|| String::from("none"))
-    );
-    println!(
-        "Next sibling: {}",
-        view.next_sibling
-            .as_ref()
-            .map(format_node_line)
-            .unwrap_or_else(|| String::from("none"))
-    );
-    println!("Children:");
-    if view.children.is_empty() {
-        println!("- none");
-    } else {
-        for child in &view.children {
-            println!("- {}", format_node_line(child));
-        }
+fn print_note_result(result: &NoteResult) {
+    println!("{}", result.note_date);
+    println!("+[{}] {}", result.node.id, result.node.rendered_content);
+}
+
+fn print_day_view(view: &DayView) {
+    println!("{}", view.note_date);
+    println!();
+    if view.entries.is_empty() {
+        println!("empty");
+        println!("use: memoryroam note \"...\"");
+        return;
     }
-    println!("Incoming links:");
-    if view.incoming_links.is_empty() {
-        println!("- none");
-    } else {
-        for incoming in &view.incoming_links {
-            println!(
-                "- {} [ordinal {}] ({})",
-                format_node_line(&incoming.source),
-                incoming.ordinal,
-                incoming.path
-            );
-        }
+
+    for entry in &view.entries {
+        println!("-[{}] {}", entry.id, entry.rendered_content);
     }
 }
 
-fn format_node_line(line: &memoryroam_domain::NodeLine) -> String {
-    format!("{} -> {}", line.id, line.rendered_content)
+fn print_root_create_result(result: &RootCreateResult) {
+    println!("root [{}] {}", result.root.id, result.root.rendered_content);
+    println!();
+    println!("matches:");
+    for entry in &result.matches {
+        println!("-[{}] {}", entry.id, entry.rendered_content);
+    }
+    if result.hidden_match_count > 0 {
+        println!("...{} more matches...", result.hidden_match_count);
+    }
+}
+
+fn print_root_apply_result(result: &RootApplyResult) {
+    println!("updated:");
+    for entry in &result.updated_nodes {
+        println!("-[{}] {}", entry.id, entry.rendered_content);
+    }
+}
+
+fn print_read_context(view: &ReadContextView) {
+    if view.prev_hidden_count > 0 {
+        println!("...prev {} sibling hiding...", view.prev_hidden_count);
+    }
+    for entry in &view.prev_siblings {
+        println!("-[{}] {}", entry.id, entry.rendered_content);
+    }
+    println!("=[{}] {}", view.current.id, view.current.rendered_content);
+    for backlink in &view.backlinks {
+        println!(
+            ">[bl:{}] {}",
+            backlink.source.id, backlink.source.rendered_content
+        );
+    }
+    if view.hidden_backlink_count > 0 {
+        println!("...{} backlinks hiding...", view.hidden_backlink_count);
+    }
+    for child in &view.children {
+        println!("--[{}] {}", child.node.id, child.node.rendered_content);
+        for backlink in &child.backlinks {
+            println!(
+                ">>[bl:{}] {}",
+                backlink.source.id, backlink.source.rendered_content
+            );
+        }
+        if child.hidden_backlink_count > 0 {
+            println!(
+                "...{} child backlinks hiding...",
+                child.hidden_backlink_count
+            );
+        }
+    }
+    if view.hidden_child_count > 0 {
+        println!("...{} children hiding...", view.hidden_child_count);
+    }
+    for entry in &view.next_siblings {
+        println!("-[{}] {}", entry.id, entry.rendered_content);
+    }
+    if view.next_hidden_count > 0 {
+        println!("...next {} sibling hiding...", view.next_hidden_count);
+    }
 }

--- a/crates/memoryroam-cli/tests/cli.rs
+++ b/crates/memoryroam-cli/tests/cli.rs
@@ -185,6 +185,20 @@ fn cli_day_rejects_invalid_dates() {
 }
 
 #[test]
+fn cli_empty_historical_day_does_not_suggest_note_command() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+
+    command(&temp_dir).arg("init").assert().success();
+
+    command(&temp_dir)
+        .args(["day", "2026-04-11"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("empty"))
+        .stdout(predicate::str::contains("use: memoryroam note").not());
+}
+
+#[test]
 fn cli_accepts_text_arguments_that_start_with_a_dash() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
 

--- a/crates/memoryroam-cli/tests/cli.rs
+++ b/crates/memoryroam-cli/tests/cli.rs
@@ -183,3 +183,22 @@ fn cli_day_rejects_invalid_dates() {
         .failure()
         .stderr(predicate::str::contains("invalid day date"));
 }
+
+#[test]
+fn cli_accepts_text_arguments_that_start_with_a_dash() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+
+    command(&temp_dir).arg("init").assert().success();
+
+    command(&temp_dir)
+        .args(["note", "- first item"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("- first item"));
+
+    command(&temp_dir)
+        .args(["root", "create", "- topic"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("root ["));
+}

--- a/crates/memoryroam-cli/tests/cli.rs
+++ b/crates/memoryroam-cli/tests/cli.rs
@@ -149,3 +149,24 @@ fn cli_read_uses_structural_markers_instead_of_field_labels() {
         )))
         .stdout(predicate::str::contains("Content:").not());
 }
+
+#[test]
+fn cli_failed_note_does_not_leave_an_empty_daily_note() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+
+    command(&temp_dir).arg("init").assert().success();
+
+    command(&temp_dir)
+        .args(["note", "See {{Missing}}"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "lookup `Missing` did not match any node",
+        ));
+
+    command(&temp_dir)
+        .arg("day")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("empty"));
+}

--- a/crates/memoryroam-cli/tests/cli.rs
+++ b/crates/memoryroam-cli/tests/cli.rs
@@ -62,6 +62,23 @@ fn cli_note_and_day_show_today_entries() {
 }
 
 #[test]
+fn cli_empty_today_hint_preserves_selected_database() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let database_path = temp_dir.path().join("notes.sqlite3");
+
+    command(&temp_dir).arg("init").assert().success();
+
+    command(&temp_dir)
+        .arg("day")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "use: memoryroam --db {} note \"...\"",
+            database_path.display()
+        )));
+}
+
+#[test]
 fn cli_root_create_and_apply_rewrite_selected_nodes() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
 

--- a/crates/memoryroam-cli/tests/cli.rs
+++ b/crates/memoryroam-cli/tests/cli.rs
@@ -10,8 +10,21 @@ fn command(temp_dir: &TempDir) -> Command {
     command
 }
 
+fn output_text(assert: assert_cmd::assert::Assert) -> String {
+    String::from_utf8(assert.get_output().stdout.clone()).expect("stdout should be utf8")
+}
+
+fn parse_bracketed_id(output: &str) -> String {
+    let start = output.find('[').expect("output should contain '['") + 1;
+    let end = output[start..]
+        .find(']')
+        .map(|offset| start + offset)
+        .expect("output should contain ']'");
+    output[start..end].to_owned()
+}
+
 #[test]
-fn cli_round_trip_supports_init_create_read_and_aliases() {
+fn cli_note_and_day_show_today_entries() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
 
     command(&temp_dir)
@@ -20,112 +33,119 @@ fn cli_round_trip_supports_init_create_read_and_aliases() {
         .success()
         .stdout(predicate::str::contains("initialized"));
 
-    command(&temp_dir)
-        .args(["create", "--content", "Topic"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("- 1"));
+    let first_output = output_text(
+        command(&temp_dir)
+            .args(["note", "Check issue 7 scope"])
+            .assert()
+            .success(),
+    );
+    let second_output = output_text(
+        command(&temp_dir)
+            .args(["note", "Design the interaction flow"])
+            .assert()
+            .success(),
+    );
+
+    let first_id = parse_bracketed_id(&first_output);
+    let second_id = parse_bracketed_id(&second_output);
 
     command(&temp_dir)
-        .args(["alias", "add", "--id", "1", "--text", "topic"])
-        .assert()
-        .success();
-
-    command(&temp_dir)
-        .args(["create", "--content", "See {{topic}}"])
+        .arg("day")
         .assert()
         .success()
-        .stdout(predicate::str::contains("- 2"));
-
-    command(&temp_dir)
-        .args(["read", "--id", "1"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("Incoming links:"))
-        .stdout(predicate::str::contains("2 -> See {{1::topic}}"));
-
-    command(&temp_dir)
-        .args(["alias", "list", "--id", "1"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("topic"));
+        .stdout(predicate::str::contains(format!(
+            "-[{first_id}] Check issue 7 scope"
+        )))
+        .stdout(predicate::str::contains(format!(
+            "-[{second_id}] Design the interaction flow"
+        )));
 }
 
 #[test]
-fn cli_delete_blocks_referenced_nodes() {
-    let temp_dir = TempDir::new().expect("temp dir should exist");
-
-    command(&temp_dir).arg("init").assert().success();
-    command(&temp_dir)
-        .args(["create", "--content", "Topic"])
-        .assert()
-        .success();
-    command(&temp_dir)
-        .args(["create", "--content", "Ref {{1}}"])
-        .assert()
-        .success();
-
-    command(&temp_dir)
-        .args(["delete", "--id", "1", "--cascade"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("still references node 1"));
-}
-
-#[test]
-fn cli_update_accepts_single_line_stdin_with_trailing_newline() {
-    let temp_dir = TempDir::new().expect("temp dir should exist");
-
-    command(&temp_dir).arg("init").assert().success();
-    command(&temp_dir)
-        .args(["create", "--content", "Topic"])
-        .assert()
-        .success();
-
-    command(&temp_dir)
-        .args(["update", "--id", "1"])
-        .write_stdin("Updated from stdin\n")
-        .assert()
-        .success();
-
-    command(&temp_dir)
-        .args(["read", "--id", "1"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("Content: Updated from stdin"));
-}
-
-#[test]
-fn cli_read_does_not_create_missing_database_files() {
-    let temp_dir = TempDir::new().expect("temp dir should exist");
-    let database_path = temp_dir.path().join("notes.sqlite3");
-
-    command(&temp_dir)
-        .args(["read", "--id", "1"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("unable to open database file"));
-
-    assert!(!database_path.exists());
-}
-
-#[test]
-fn cli_multiline_create_rolls_back_on_later_failure() {
+fn cli_root_create_and_apply_rewrite_selected_nodes() {
     let temp_dir = TempDir::new().expect("temp dir should exist");
 
     command(&temp_dir).arg("init").assert().success();
 
-    command(&temp_dir)
-        .args(["create", "--content", "First\nRef {{Missing}}"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "lookup `Missing` did not match any node",
-        ));
+    let first_output = output_text(
+        command(&temp_dir)
+            .args(["note", "Software engineering is an engineering discipline"])
+            .assert()
+            .success(),
+    );
+    let second_output = output_text(
+        command(&temp_dir)
+            .args(["note", "Software engineering started in xx year"])
+            .assert()
+            .success(),
+    );
+
+    let first_id = parse_bracketed_id(&first_output);
+    let second_id = parse_bracketed_id(&second_output);
+
+    let root_output = output_text(
+        command(&temp_dir)
+            .args(["root", "create", "Software engineering"])
+            .assert()
+            .success(),
+    );
+    let root_id = parse_bracketed_id(&root_output);
 
     command(&temp_dir)
-        .args(["list", "--top-level"])
+        .args([
+            "root", "apply", &root_id, "--node", &first_id, "--node", &second_id,
+        ])
         .assert()
         .success()
-        .stdout(predicate::str::is_empty());
+        .stdout(predicate::str::contains(format!(
+            "-[{first_id}] {{{{{root_id}::Software engineering}}}} is an engineering discipline"
+        )))
+        .stdout(predicate::str::contains(format!(
+            "-[{second_id}] {{{{{root_id}::Software engineering}}}} started in xx year"
+        )));
+}
+
+#[test]
+fn cli_read_uses_structural_markers_instead_of_field_labels() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+
+    command(&temp_dir).arg("init").assert().success();
+
+    let first_output = output_text(
+        command(&temp_dir)
+            .args(["note", "Previous sibling"])
+            .assert()
+            .success(),
+    );
+    let current_output = output_text(
+        command(&temp_dir)
+            .args(["note", "Current node"])
+            .assert()
+            .success(),
+    );
+    let next_output = output_text(
+        command(&temp_dir)
+            .args(["note", "Next sibling"])
+            .assert()
+            .success(),
+    );
+
+    let first_id = parse_bracketed_id(&first_output);
+    let current_id = parse_bracketed_id(&current_output);
+    let next_id = parse_bracketed_id(&next_output);
+
+    command(&temp_dir)
+        .args(["read", &current_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "-[{first_id}] Previous sibling"
+        )))
+        .stdout(predicate::str::contains(format!(
+            "=[{current_id}] Current node"
+        )))
+        .stdout(predicate::str::contains(format!(
+            "-[{next_id}] Next sibling"
+        )))
+        .stdout(predicate::str::contains("Content:").not());
 }

--- a/crates/memoryroam-cli/tests/cli.rs
+++ b/crates/memoryroam-cli/tests/cli.rs
@@ -73,9 +73,12 @@ fn cli_empty_today_hint_preserves_selected_database() {
         .assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "use: memoryroam --db '{}' note \"...\"",
+            "database path: {}",
             database_path.display()
-        )));
+        )))
+        .stdout(predicate::str::contains(
+            "use: memoryroam --db <database-path> note \"...\"",
+        ));
 }
 
 #[test]
@@ -92,9 +95,12 @@ fn cli_empty_today_hint_quotes_database_paths_with_spaces() {
     day.assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "use: memoryroam --db '{}' note \"...\"",
+            "database path: {}",
             database_path.display()
-        )));
+        )))
+        .stdout(predicate::str::contains(
+            "use: memoryroam --db <database-path> note \"...\"",
+        ));
 }
 
 #[test]

--- a/crates/memoryroam-cli/tests/cli.rs
+++ b/crates/memoryroam-cli/tests/cli.rs
@@ -170,3 +170,16 @@ fn cli_failed_note_does_not_leave_an_empty_daily_note() {
         .success()
         .stdout(predicate::str::contains("empty"));
 }
+
+#[test]
+fn cli_day_rejects_invalid_dates() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+
+    command(&temp_dir).arg("init").assert().success();
+
+    command(&temp_dir)
+        .args(["day", "2026-99-99"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid day date"));
+}

--- a/crates/memoryroam-cli/tests/cli.rs
+++ b/crates/memoryroam-cli/tests/cli.rs
@@ -73,7 +73,26 @@ fn cli_empty_today_hint_preserves_selected_database() {
         .assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "use: memoryroam --db {} note \"...\"",
+            "use: memoryroam --db '{}' note \"...\"",
+            database_path.display()
+        )));
+}
+
+#[test]
+fn cli_empty_today_hint_quotes_database_paths_with_spaces() {
+    let temp_dir = TempDir::new().expect("temp dir should exist");
+    let database_path = temp_dir.path().join("notes with spaces.sqlite3");
+
+    let mut init = Command::cargo_bin("memoryroam").expect("binary should build");
+    init.arg("--db").arg(&database_path).arg("init");
+    init.assert().success();
+
+    let mut day = Command::cargo_bin("memoryroam").expect("binary should build");
+    day.arg("--db").arg(&database_path).arg("day");
+    day.assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "use: memoryroam --db '{}' note \"...\"",
             database_path.display()
         )));
 }

--- a/crates/memoryroam-domain/src/lib.rs
+++ b/crates/memoryroam-domain/src/lib.rs
@@ -237,6 +237,13 @@ pub struct LookupCandidate {
     pub path: String,
 }
 
+/// One daily note entry keyed by ISO date text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DailyNoteRecord {
+    pub note_date: String,
+    pub node_id: NodeId,
+}
+
 /// One incoming-link occurrence returned by storage.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncomingLinkRecord {
@@ -287,6 +294,15 @@ pub struct NewNodeRecord {
     pub lookup_key: LookupKey,
     pub outgoing_links: Vec<NodeId>,
     pub aliases: Vec<AliasText>,
+}
+
+/// One canonicalized node update payload ready for storage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeUpdateRecord {
+    pub node_id: NodeId,
+    pub content: ContentLine,
+    pub lookup_key: LookupKey,
+    pub outgoing_links: Vec<NodeId>,
 }
 
 /// Placement target used by create, move, and delete-reparent operations.
@@ -367,6 +383,20 @@ pub trait ReadRepository {
     fn lookup_candidates(&self, key: &LookupKey) -> KernelResult<Vec<LookupCandidate>>;
     /// Returns the rendered breadcrumb path for one node.
     fn node_path(&self, node_id: NodeId) -> KernelResult<String>;
+    /// Returns the daily note node for one ISO date, if present.
+    fn find_daily_note(&self, note_date: &str) -> KernelResult<Option<DailyNoteRecord>>;
+    /// Lists all daily note records in ascending date order.
+    fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>>;
+    /// Returns whether the given node is a daily note date node.
+    fn is_daily_note_node(&self, node_id: NodeId) -> KernelResult<bool>;
+    /// Returns whether the given node is a root top-level node.
+    fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool>;
+    /// Lists all root top-level nodes in stable order.
+    fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>>;
+    /// Finds one root node whose content exactly matches the input content.
+    fn find_root_node_by_content(&self, content: &ContentLine) -> KernelResult<Option<StoredNode>>;
+    /// Returns non-root, non-daily nodes whose raw content contains the substring.
+    fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>>;
 
     /// Returns whether the given node currently exists.
     fn node_exists(&self, node_id: NodeId) -> KernelResult<bool> {
@@ -392,13 +422,7 @@ pub trait WriteRepository: ReadRepository {
         nodes: &[NewNodeRecord],
     ) -> KernelResult<Vec<NodeId>>;
     /// Replaces one node's canonical content and outgoing links.
-    fn update_node_content(
-        &mut self,
-        node_id: NodeId,
-        content: &ContentLine,
-        lookup_key: &LookupKey,
-        outgoing_links: &[NodeId],
-    ) -> KernelResult<()>;
+    fn update_node_contents(&mut self, updates: &[NodeUpdateRecord]) -> KernelResult<()>;
     /// Moves one existing node or subtree to a new placement.
     fn move_node(&mut self, node_id: NodeId, placement: Placement) -> KernelResult<()>;
     /// Deletes one node using the requested mode.
@@ -407,6 +431,10 @@ pub trait WriteRepository: ReadRepository {
     fn add_aliases(&mut self, node_id: NodeId, aliases: &[AliasText]) -> KernelResult<()>;
     /// Removes one alias from one node.
     fn remove_alias(&mut self, node_id: NodeId, alias: &AliasText) -> KernelResult<()>;
+    /// Creates one root top-level node.
+    fn create_root_node(&mut self, node: &NewNodeRecord) -> KernelResult<NodeId>;
+    /// Creates one daily note date node for the provided ISO date.
+    fn create_daily_note_node(&mut self, note_date: &str) -> KernelResult<NodeId>;
 }
 
 /// Parses a validated content line into plain-text and link fragments.
@@ -767,6 +795,37 @@ mod tests {
 
         fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
             Ok(format!("path:{node_id}"))
+        }
+
+        fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+            Ok(None)
+        }
+
+        fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+
+        fn find_root_node_by_content(
+            &self,
+            _content: &ContentLine,
+        ) -> KernelResult<Option<StoredNode>> {
+            Ok(None)
+        }
+
+        fn search_text_matches(&self, _needle: &str) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
         }
     }
 

--- a/crates/memoryroam-domain/src/lib.rs
+++ b/crates/memoryroam-domain/src/lib.rs
@@ -435,6 +435,12 @@ pub trait WriteRepository: ReadRepository {
     fn create_root_node(&mut self, node: &NewNodeRecord) -> KernelResult<NodeId>;
     /// Creates one daily note date node for the provided ISO date.
     fn create_daily_note_node(&mut self, note_date: &str) -> KernelResult<NodeId>;
+    /// Atomically ensures one daily note exists and appends one child note under it.
+    fn create_note_in_daily_note(
+        &mut self,
+        note_date: &str,
+        node: &NewNodeRecord,
+    ) -> KernelResult<NodeId>;
 }
 
 /// Parses a validated content line into plain-text and link fragments.

--- a/crates/memoryroam-read/README.md
+++ b/crates/memoryroam-read/README.md
@@ -15,8 +15,8 @@ This crate owns the rendered read workflows that the CLI exposes:
 
 ```rust,no_run
 use memoryroam_domain::{
-    AliasText, ContentLine, IncomingLinkRecord, KernelResult, LookupCandidate, NodeId,
-    ReadRepository, StoredNode,
+    AliasText, ContentLine, DailyNoteRecord, IncomingLinkRecord, KernelResult, LookupCandidate,
+    NodeId, ReadRepository, StoredNode,
 };
 use memoryroam_read::read_node;
 use std::collections::{BTreeMap, BTreeSet};
@@ -32,6 +32,13 @@ impl ReadRepository for Repo {
     fn fetch_node_contents(&self, _node_ids: &BTreeSet<NodeId>) -> KernelResult<BTreeMap<NodeId, ContentLine>> { todo!() }
     fn lookup_candidates(&self, _key: &memoryroam_domain::LookupKey) -> KernelResult<Vec<LookupCandidate>> { todo!() }
     fn node_path(&self, _node_id: NodeId) -> KernelResult<String> { todo!() }
+    fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> { todo!() }
+    fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> { todo!() }
+    fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> { todo!() }
+    fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> { todo!() }
+    fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> { todo!() }
+    fn find_root_node_by_content(&self, _content: &ContentLine) -> KernelResult<Option<StoredNode>> { todo!() }
+    fn search_text_matches(&self, _needle: &str) -> KernelResult<Vec<StoredNode>> { todo!() }
 }
 
 let repo = Repo;

--- a/crates/memoryroam-read/src/lib.rs
+++ b/crates/memoryroam-read/src/lib.rs
@@ -118,8 +118,8 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
 
     use memoryroam_domain::{
-        AliasText, ContentLine, IncomingLinkRecord, LookupCandidate, NodeId, ReadRepository,
-        StoredNode,
+        AliasText, ContentLine, DailyNoteRecord, IncomingLinkRecord, LookupCandidate, NodeId,
+        ReadRepository, StoredNode,
     };
 
     use super::*;
@@ -193,6 +193,47 @@ mod tests {
 
         fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
             Ok(format!("path:{node_id}"))
+        }
+
+        fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+            Ok(None)
+        }
+
+        fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+            Ok(self
+                .nodes
+                .values()
+                .filter(|node| node.parent_id.is_none())
+                .cloned()
+                .collect())
+        }
+
+        fn find_root_node_by_content(
+            &self,
+            _content: &ContentLine,
+        ) -> KernelResult<Option<StoredNode>> {
+            Ok(None)
+        }
+
+        fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+            Ok(self
+                .nodes
+                .values()
+                .filter(|node| node.content.as_str().contains(needle))
+                .cloned()
+                .collect())
         }
     }
 

--- a/crates/memoryroam-read/src/lib.rs
+++ b/crates/memoryroam-read/src/lib.rs
@@ -17,8 +17,29 @@ pub fn read_node<R: ReadRepository>(repository: &R, node_id: NodeId) -> KernelRe
 
     let node_line = render_node_line(repository, &node)?;
     let parent = load_related_node_line(repository, node.parent_id)?;
-    let prev_sibling = load_related_node_line(repository, node.prev_sibling_id)?;
-    let next_sibling = load_related_node_line(repository, node.next_sibling_id)?;
+    let (prev_sibling_id, next_sibling_id) = if repository.is_root_node(node_id)? {
+        find_top_level_neighbors(
+            repository
+                .list_root_nodes()?
+                .into_iter()
+                .map(|node| node.id)
+                .collect(),
+            node_id,
+        )?
+    } else if repository.is_daily_note_node(node_id)? {
+        find_top_level_neighbors(
+            repository
+                .list_daily_notes()?
+                .into_iter()
+                .map(|record| record.node_id)
+                .collect(),
+            node_id,
+        )?
+    } else {
+        (node.prev_sibling_id, node.next_sibling_id)
+    };
+    let prev_sibling = load_related_node_line(repository, prev_sibling_id)?;
+    let next_sibling = load_related_node_line(repository, next_sibling_id)?;
     let children = repository
         .list_children(Some(node_id))?
         .iter()
@@ -113,6 +134,21 @@ fn render_node_line<R: ReadRepository>(
     })
 }
 
+fn find_top_level_neighbors(
+    node_ids: Vec<NodeId>,
+    current_id: NodeId,
+) -> KernelResult<(Option<NodeId>, Option<NodeId>)> {
+    let current_index = node_ids
+        .iter()
+        .position(|node_id| *node_id == current_id)
+        .ok_or(KernelError::StorageCorruption(format!(
+            "missing top-level node {current_id}"
+        )))?;
+    let prev = current_index.checked_sub(1).map(|index| node_ids[index]);
+    let next = node_ids.get(current_index + 1).copied();
+    Ok((prev, next))
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -128,6 +164,7 @@ mod tests {
         nodes: BTreeMap<NodeId, StoredNode>,
         aliases: BTreeMap<NodeId, Vec<AliasText>>,
         incoming_links: BTreeMap<NodeId, Vec<IncomingLinkRecord>>,
+        root_nodes: Vec<NodeId>,
     }
 
     impl FakeRepository {
@@ -136,6 +173,7 @@ mod tests {
                 nodes: nodes.into_iter().map(|node| (node.id, node)).collect(),
                 aliases: BTreeMap::new(),
                 incoming_links: BTreeMap::new(),
+                root_nodes: Vec::new(),
             }
         }
     }
@@ -208,15 +246,14 @@ mod tests {
         }
 
         fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> {
-            Ok(false)
+            Ok(self.root_nodes.contains(&_node_id))
         }
 
         fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
             Ok(self
-                .nodes
-                .values()
-                .filter(|node| node.parent_id.is_none())
-                .cloned()
+                .root_nodes
+                .iter()
+                .filter_map(|node_id| self.nodes.get(node_id).cloned())
                 .collect())
         }
 
@@ -293,6 +330,58 @@ mod tests {
         assert_eq!(
             view.incoming_links[0].source.rendered_content,
             "Source {{1::>Current}}"
+        );
+    }
+
+    #[test]
+    fn read_node_uses_top_level_neighbors_for_root_nodes() {
+        let first_id = NodeId::new(1).expect("valid test id");
+        let current_id = NodeId::new(2).expect("valid test id");
+        let next_id = NodeId::new(3).expect("valid test id");
+
+        let first = StoredNode {
+            id: first_id,
+            content: ContentLine::parse("First").expect("valid content"),
+            parent_id: None,
+            first_child_id: None,
+            last_child_id: None,
+            prev_sibling_id: None,
+            next_sibling_id: None,
+        };
+        let current = StoredNode {
+            id: current_id,
+            content: ContentLine::parse("Current").expect("valid content"),
+            parent_id: None,
+            first_child_id: None,
+            last_child_id: None,
+            prev_sibling_id: None,
+            next_sibling_id: None,
+        };
+        let next = StoredNode {
+            id: next_id,
+            content: ContentLine::parse("Next").expect("valid content"),
+            parent_id: None,
+            first_child_id: None,
+            last_child_id: None,
+            prev_sibling_id: None,
+            next_sibling_id: None,
+        };
+
+        let mut repository = FakeRepository::new(vec![first, current, next]);
+        repository.root_nodes = vec![first_id, current_id, next_id];
+
+        let view = read_node(&repository, current_id).expect("read should succeed");
+        assert_eq!(
+            view.prev_sibling
+                .expect("prev should exist")
+                .rendered_content,
+            "First"
+        );
+        assert_eq!(
+            view.next_sibling
+                .expect("next should exist")
+                .rendered_content,
+            "Next"
         );
     }
 }

--- a/crates/memoryroam-storage-sqlite/README.md
+++ b/crates/memoryroam-storage-sqlite/README.md
@@ -45,3 +45,4 @@ let _path = store.database_path();
 - The crate uses the bundled SQLite library through `rusqlite`.
 - Batch creation and cycle checks run inside the same SQLite transaction.
 - Read-only commands use `open_existing` so a mistyped path does not create an empty database file.
+- The current schema is for the unreleased note-taking redesign only; older database files are out of scope and no migration path is provided.

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -959,13 +959,22 @@ impl WriteRepository for SqliteStore {
                     aliases: Vec::new(),
                 };
                 let note_node_id = insert_top_level_node(&transaction, &note_node)?;
-                transaction
-                    .execute(
-                        "INSERT INTO daily_notes (note_date, node_id) VALUES (?1, ?2)",
-                        params![note_date, note_node_id.value()],
-                    )
-                    .map_err(map_sqlite_error)?;
-                note_node_id
+                match transaction.execute(
+                    "INSERT INTO daily_notes (note_date, node_id) VALUES (?1, ?2)",
+                    params![note_date, note_node_id.value()],
+                ) {
+                    Ok(_) => note_node_id,
+                    Err(error) => match map_sqlite_error(error) {
+                        KernelError::Constraint(_) => {
+                            find_daily_note_from_handle(&transaction, note_date)?
+                                .map(|record| record.node_id)
+                                .ok_or(KernelError::Constraint(format!(
+                                    "daily note {note_date} could not be created"
+                                )))?
+                        }
+                        other => return Err(other),
+                    },
+                }
             }
         };
 

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -8,9 +8,9 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use memoryroam_domain::{
-    AliasText, ContentLine, DeleteMode, IncomingLinkRecord, KernelError, KernelResult,
-    LookupCandidate, LookupKey, NewNodeRecord, NodeId, Placement, ReadRepository, StoredNode,
-    WriteRepository, canonicalize_content,
+    AliasText, ContentLine, DailyNoteRecord, DeleteMode, IncomingLinkRecord, KernelError,
+    KernelResult, LookupCandidate, LookupKey, NewNodeRecord, NodeId, NodeUpdateRecord, Placement,
+    ReadRepository, StoredNode, WriteRepository, canonicalize_content,
 };
 use rusqlite::types::Type;
 use rusqlite::{
@@ -38,12 +38,30 @@ CREATE TABLE IF NOT EXISTS nodes (
     CHECK (instr(content_lookup_key, char(10)) = 0 AND instr(content_lookup_key, char(13)) = 0),
 
     CHECK ((first_child_id IS NULL) = (last_child_id IS NULL)),
+    CHECK (parent_id IS NOT NULL OR (prev_sibling_id IS NULL AND next_sibling_id IS NULL)),
 
     CHECK (parent_id IS NULL OR parent_id <> id),
     CHECK (first_child_id IS NULL OR first_child_id <> id),
     CHECK (last_child_id IS NULL OR last_child_id <> id),
     CHECK (prev_sibling_id IS NULL OR prev_sibling_id <> id),
     CHECK (next_sibling_id IS NULL OR next_sibling_id <> id)
+);
+
+CREATE TABLE IF NOT EXISTS root_nodes (
+    node_id INTEGER PRIMARY KEY
+            REFERENCES nodes(id)
+            ON DELETE RESTRICT
+            DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS daily_notes (
+    note_date TEXT PRIMARY KEY,
+    node_id   INTEGER NOT NULL UNIQUE
+              REFERENCES nodes(id)
+              ON DELETE RESTRICT
+              DEFERRABLE INITIALLY DEFERRED,
+
+    CHECK (date(note_date) = note_date)
 );
 
 CREATE TABLE IF NOT EXISTS node_aliases (
@@ -81,23 +99,14 @@ CREATE TABLE IF NOT EXISTS node_links (
     CHECK (ordinal >= 1)
 );
 
-CREATE TABLE IF NOT EXISTS tree_root (
-    root_id         INTEGER PRIMARY KEY CHECK (root_id = 1),
-    first_child_id  INTEGER REFERENCES nodes(id) DEFERRABLE INITIALLY DEFERRED,
-    last_child_id   INTEGER REFERENCES nodes(id) DEFERRABLE INITIALLY DEFERRED,
-
-    CHECK ((first_child_id IS NULL) = (last_child_id IS NULL))
-);
-
-INSERT INTO tree_root(root_id, first_child_id, last_child_id)
-VALUES (1, NULL, NULL)
-ON CONFLICT(root_id) DO NOTHING;
-
 CREATE INDEX IF NOT EXISTS idx_nodes_parent_id
     ON nodes(parent_id);
 
 CREATE INDEX IF NOT EXISTS idx_nodes_content_lookup_key
     ON nodes(content_lookup_key);
+
+CREATE INDEX IF NOT EXISTS idx_daily_notes_node_id
+    ON daily_notes(node_id);
 
 CREATE INDEX IF NOT EXISTS idx_aliases_alias_key
     ON node_aliases(alias_key, node_id);
@@ -111,12 +120,14 @@ SELECT
     content_lookup_key AS lookup_key,
     'content' AS match_kind
 FROM nodes
+WHERE id NOT IN (SELECT node_id FROM daily_notes)
 UNION ALL
 SELECT
-    node_id,
+    a.node_id,
     alias_key AS lookup_key,
     'alias' AS match_kind
-FROM node_aliases;
+FROM node_aliases AS a
+WHERE a.node_id NOT IN (SELECT node_id FROM daily_notes);
 
 CREATE VIEW IF NOT EXISTS v_incoming_links AS
 SELECT
@@ -150,7 +161,100 @@ BEGIN
     );
 END;
 
-PRAGMA user_version = 1;
+CREATE TRIGGER IF NOT EXISTS root_nodes_validate_insert
+BEFORE INSERT ON root_nodes
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'root node must be a top-level node without siblings')
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM nodes
+        WHERE id = NEW.node_id
+          AND parent_id IS NULL
+          AND prev_sibling_id IS NULL
+          AND next_sibling_id IS NULL
+    );
+
+    SELECT RAISE(ABORT, 'root node cannot also be a daily note')
+    WHERE EXISTS (
+        SELECT 1
+        FROM daily_notes
+        WHERE node_id = NEW.node_id
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert
+BEFORE INSERT ON daily_notes
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'daily note node must be a top-level node without siblings')
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM nodes
+        WHERE id = NEW.node_id
+          AND parent_id IS NULL
+          AND prev_sibling_id IS NULL
+          AND next_sibling_id IS NULL
+          AND content = NEW.note_date
+    );
+
+    SELECT RAISE(ABORT, 'daily note node cannot also be a root node')
+    WHERE EXISTS (
+        SELECT 1
+        FROM root_nodes
+        WHERE node_id = NEW.node_id
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS daily_note_nodes_reject_update
+BEFORE UPDATE OF content, parent_id, prev_sibling_id, next_sibling_id ON nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM daily_notes
+    WHERE node_id = OLD.id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'daily note date nodes are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS daily_note_nodes_reject_delete
+BEFORE DELETE ON nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM daily_notes
+    WHERE node_id = OLD.id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'daily note date nodes are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS node_aliases_reject_daily_note_insert
+BEFORE INSERT ON node_aliases
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM daily_notes
+    WHERE node_id = NEW.node_id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'daily note date nodes cannot have aliases');
+END;
+
+CREATE TRIGGER IF NOT EXISTS node_aliases_reject_daily_note_delete
+BEFORE DELETE ON node_aliases
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM daily_notes
+    WHERE node_id = OLD.node_id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'daily note date nodes cannot have aliases');
+END;
+
+PRAGMA user_version = 2;
 "#;
 
 /// SQLite-backed repository implementation for MemoryRoam.
@@ -205,19 +309,17 @@ impl ReadRepository for SqliteStore {
 
     fn list_children(&self, parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
         ensure_schema_initialized(&self.connection)?;
-        let start = match parent_id {
+        match parent_id {
             Some(parent_id) => {
                 let parent =
                     fetch_node(&self.connection, parent_id)?.ok_or(KernelError::NotFound {
                         entity: "node",
                         id: parent_id,
                     })?;
-                parent.first_child_id
+                follow_chain(&self.connection, parent.first_child_id)
             }
-            None => fetch_root(&self.connection)?.first_child_id,
-        };
-
-        follow_chain(&self.connection, start)
+            None => list_root_nodes_from_handle(&self.connection),
+        }
     }
 
     fn list_outgoing_links(&self, node_id: NodeId) -> KernelResult<Vec<NodeId>> {
@@ -356,6 +458,41 @@ impl ReadRepository for SqliteStore {
         segments.reverse();
         Ok(segments.join(" > "))
     }
+
+    fn find_daily_note(&self, note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+        ensure_schema_initialized(&self.connection)?;
+        find_daily_note_from_handle(&self.connection, note_date)
+    }
+
+    fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+        ensure_schema_initialized(&self.connection)?;
+        list_daily_notes_from_handle(&self.connection)
+    }
+
+    fn is_daily_note_node(&self, node_id: NodeId) -> KernelResult<bool> {
+        ensure_schema_initialized(&self.connection)?;
+        is_daily_note_node_in_handle(&self.connection, node_id)
+    }
+
+    fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+        ensure_schema_initialized(&self.connection)?;
+        is_root_node_in_handle(&self.connection, node_id)
+    }
+
+    fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+        ensure_schema_initialized(&self.connection)?;
+        list_root_nodes_from_handle(&self.connection)
+    }
+
+    fn find_root_node_by_content(&self, content: &ContentLine) -> KernelResult<Option<StoredNode>> {
+        ensure_schema_initialized(&self.connection)?;
+        find_root_node_by_content_from_handle(&self.connection, content)
+    }
+
+    fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+        ensure_schema_initialized(&self.connection)?;
+        search_text_matches_from_handle(&self.connection, needle)
+    }
 }
 
 impl WriteRepository for SqliteStore {
@@ -486,30 +623,37 @@ impl WriteRepository for SqliteStore {
         Ok(inserted_ids)
     }
 
-    fn update_node_content(
-        &mut self,
-        node_id: NodeId,
-        content: &ContentLine,
-        lookup_key: &LookupKey,
-        outgoing_links: &[NodeId],
-    ) -> KernelResult<()> {
+    fn update_node_contents(&mut self, updates: &[NodeUpdateRecord]) -> KernelResult<()> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
         let transaction = self.connection.transaction().map_err(map_sqlite_error)?;
         ensure_schema_initialized(&transaction)?;
-        ensure_node_exists_in_db(&transaction, node_id)?;
 
-        transaction
-            .execute(
-                "UPDATE nodes
-                 SET content = ?1, content_lookup_key = ?2
-                 WHERE id = ?3",
-                params![content.as_str(), lookup_key.as_str(), node_id.value()],
-            )
-            .map_err(map_sqlite_error)?;
-        refresh_outgoing_links(&transaction, node_id, outgoing_links)?;
+        for update in updates {
+            ensure_node_exists_in_db(&transaction, update.node_id)?;
+            transaction
+                .execute(
+                    "UPDATE nodes
+                     SET content = ?1, content_lookup_key = ?2
+                     WHERE id = ?3",
+                    params![
+                        update.content.as_str(),
+                        update.lookup_key.as_str(),
+                        update.node_id.value()
+                    ],
+                )
+                .map_err(map_sqlite_error)?;
+            refresh_outgoing_links(&transaction, update.node_id, &update.outgoing_links)?;
+        }
+
         let repository = TransactionRepository {
             transaction: &transaction,
         };
-        ensure_no_link_cycle(&repository, node_id)?;
+        for update in updates {
+            ensure_no_link_cycle(&repository, update.node_id)?;
+        }
 
         transaction.commit().map_err(map_sqlite_error)
     }
@@ -537,6 +681,7 @@ impl WriteRepository for SqliteStore {
             entity: "node",
             id: node_id,
         })?;
+        let node_is_root = is_root_node_in_handle(&transaction, node_id)?;
 
         match mode {
             DeleteMode::Cascade => {
@@ -548,7 +693,20 @@ impl WriteRepository for SqliteStore {
                     )));
                 }
 
-                detach_node(&transaction, &node)?;
+                if node.parent_id.is_some() {
+                    detach_node(&transaction, &node)?;
+                } else if node_is_root {
+                    transaction
+                        .execute(
+                            "DELETE FROM root_nodes WHERE node_id = ?1",
+                            params![node_id.value()],
+                        )
+                        .map_err(map_sqlite_error)?;
+                } else {
+                    return Err(KernelError::Constraint(format!(
+                        "top-level node {node_id} cannot be deleted"
+                    )));
+                }
                 transaction
                     .execute(
                         "WITH RECURSIVE subtree(id) AS (
@@ -565,6 +723,12 @@ impl WriteRepository for SqliteStore {
                     .map_err(map_sqlite_error)?;
             }
             DeleteMode::Reparent(placement) => {
+                if node.parent_id.is_none() {
+                    return Err(KernelError::Constraint(format!(
+                        "top-level node {node_id} cannot be reparent-deleted"
+                    )));
+                }
+
                 if let Some(incoming) = find_incoming_link(&transaction, node_id)? {
                     return Err(KernelError::Constraint(format!(
                         "node {node_id} is still referenced by node {}",
@@ -635,6 +799,54 @@ impl WriteRepository for SqliteStore {
 
         transaction.commit().map_err(map_sqlite_error)
     }
+
+    fn create_root_node(&mut self, node: &NewNodeRecord) -> KernelResult<NodeId> {
+        let transaction = self.connection.transaction().map_err(map_sqlite_error)?;
+        ensure_schema_initialized(&transaction)?;
+
+        let node_id = insert_top_level_node(&transaction, node)?;
+        transaction
+            .execute(
+                "INSERT INTO root_nodes (node_id) VALUES (?1)",
+                params![node_id.value()],
+            )
+            .map_err(map_sqlite_error)?;
+
+        let repository = TransactionRepository {
+            transaction: &transaction,
+        };
+        ensure_no_link_cycle(&repository, node_id)?;
+
+        transaction.commit().map_err(map_sqlite_error)?;
+        Ok(node_id)
+    }
+
+    fn create_daily_note_node(&mut self, note_date: &str) -> KernelResult<NodeId> {
+        let transaction = self.connection.transaction().map_err(map_sqlite_error)?;
+        ensure_schema_initialized(&transaction)?;
+
+        let content =
+            ContentLine::parse(note_date).map_err(|error| KernelError::Input(error.to_string()))?;
+        let lookup_key = LookupKey::from_content(&content)
+            .map_err(|error| KernelError::Input(error.to_string()))?;
+        let node = NewNodeRecord {
+            content,
+            lookup_key,
+            outgoing_links: Vec::new(),
+            aliases: Vec::new(),
+        };
+
+        let node_id = insert_top_level_node(&transaction, &node)?;
+        transaction
+            .execute(
+                "INSERT INTO daily_notes (note_date, node_id) VALUES (?1, ?2)",
+                params![note_date, node_id.value()],
+            )
+            .map_err(map_sqlite_error)?;
+
+        transaction.commit().map_err(map_sqlite_error)?;
+        Ok(node_id)
+    }
 }
 
 trait SqlHandle {
@@ -662,19 +874,17 @@ impl ReadRepository for TransactionRepository<'_> {
     }
 
     fn list_children(&self, parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
-        let start = match parent_id {
+        match parent_id {
             Some(parent_id) => {
                 let parent =
                     fetch_node(self.transaction, parent_id)?.ok_or(KernelError::NotFound {
                         entity: "node",
                         id: parent_id,
                     })?;
-                parent.first_child_id
+                follow_chain(self.transaction, parent.first_child_id)
             }
-            None => fetch_root(self.transaction)?.first_child_id,
-        };
-
-        follow_chain(self.transaction, start)
+            None => list_root_nodes_from_handle(self.transaction),
+        }
     }
 
     fn list_outgoing_links(&self, node_id: NodeId) -> KernelResult<Vec<NodeId>> {
@@ -806,6 +1016,34 @@ impl ReadRepository for TransactionRepository<'_> {
         segments.reverse();
         Ok(segments.join(" > "))
     }
+
+    fn find_daily_note(&self, note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+        find_daily_note_from_handle(self.transaction, note_date)
+    }
+
+    fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+        list_daily_notes_from_handle(self.transaction)
+    }
+
+    fn is_daily_note_node(&self, node_id: NodeId) -> KernelResult<bool> {
+        is_daily_note_node_in_handle(self.transaction, node_id)
+    }
+
+    fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+        is_root_node_in_handle(self.transaction, node_id)
+    }
+
+    fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+        list_root_nodes_from_handle(self.transaction)
+    }
+
+    fn find_root_node_by_content(&self, content: &ContentLine) -> KernelResult<Option<StoredNode>> {
+        find_root_node_by_content_from_handle(self.transaction, content)
+    }
+
+    fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+        search_text_matches_from_handle(self.transaction, needle)
+    }
 }
 
 impl ReadRepository for BatchCreateRepository<'_> {
@@ -814,19 +1052,17 @@ impl ReadRepository for BatchCreateRepository<'_> {
     }
 
     fn list_children(&self, parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
-        let start = match parent_id {
+        match parent_id {
             Some(parent_id) => {
                 let parent =
                     fetch_node(self.transaction, parent_id)?.ok_or(KernelError::NotFound {
                         entity: "node",
                         id: parent_id,
                     })?;
-                parent.first_child_id
+                follow_chain(self.transaction, parent.first_child_id)
             }
-            None => fetch_root(self.transaction)?.first_child_id,
-        };
-
-        follow_chain(self.transaction, start)
+            None => list_root_nodes_from_handle(self.transaction),
+        }
     }
 
     fn list_outgoing_links(&self, node_id: NodeId) -> KernelResult<Vec<NodeId>> {
@@ -885,6 +1121,55 @@ impl ReadRepository for BatchCreateRepository<'_> {
         }
         .node_path(node_id)
     }
+
+    fn find_daily_note(&self, note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+        TransactionRepository {
+            transaction: self.transaction,
+        }
+        .find_daily_note(note_date)
+    }
+
+    fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+        TransactionRepository {
+            transaction: self.transaction,
+        }
+        .list_daily_notes()
+    }
+
+    fn is_daily_note_node(&self, node_id: NodeId) -> KernelResult<bool> {
+        TransactionRepository {
+            transaction: self.transaction,
+        }
+        .is_daily_note_node(node_id)
+    }
+
+    fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+        TransactionRepository {
+            transaction: self.transaction,
+        }
+        .is_root_node(node_id)
+    }
+
+    fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+        TransactionRepository {
+            transaction: self.transaction,
+        }
+        .list_root_nodes()
+    }
+
+    fn find_root_node_by_content(&self, content: &ContentLine) -> KernelResult<Option<StoredNode>> {
+        TransactionRepository {
+            transaction: self.transaction,
+        }
+        .find_root_node_by_content(content)
+    }
+
+    fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+        TransactionRepository {
+            transaction: self.transaction,
+        }
+        .search_text_matches(needle)
+    }
 }
 
 impl SqlHandle for Connection {
@@ -931,17 +1216,11 @@ impl SqlHandle for Transaction<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-struct RootRecord {
-    first_child_id: Option<NodeId>,
-    last_child_id: Option<NodeId>,
-}
-
 fn ensure_schema_initialized(handle: &impl SqlHandle) -> KernelResult<()> {
     let version = handle
         .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
         .map_err(map_sqlite_error)?;
-    if version != 1 {
+    if version != 2 {
         return Err(KernelError::Storage(format!(
             "unsupported schema version {version}; run `memoryroam init`"
         )));
@@ -1018,21 +1297,161 @@ fn fetch_node(handle: &impl SqlHandle, node_id: NodeId) -> KernelResult<Option<S
         .map_err(map_sqlite_error)
 }
 
-fn fetch_root(handle: &impl SqlHandle) -> KernelResult<RootRecord> {
+fn find_daily_note_from_handle(
+    handle: &impl SqlHandle,
+    note_date: &str,
+) -> KernelResult<Option<DailyNoteRecord>> {
     handle
         .query_row(
-            "SELECT first_child_id, last_child_id
-             FROM tree_root
-             WHERE root_id = 1",
-            [],
+            "SELECT note_date, node_id
+             FROM daily_notes
+             WHERE note_date = ?1",
+            params![note_date],
             |row| {
-                Ok(RootRecord {
-                    first_child_id: optional_node_id_from_row(row, 0)?,
-                    last_child_id: optional_node_id_from_row(row, 1)?,
+                Ok(DailyNoteRecord {
+                    note_date: row.get::<_, String>(0)?,
+                    node_id: node_id_from_row(row, 1)?,
                 })
             },
         )
+        .optional()
         .map_err(map_sqlite_error)
+}
+
+fn list_daily_notes_from_handle(handle: &impl SqlHandle) -> KernelResult<Vec<DailyNoteRecord>> {
+    let mut statement = handle
+        .prepare(
+            "SELECT note_date, node_id
+             FROM daily_notes
+             ORDER BY note_date",
+        )
+        .map_err(map_sqlite_error)?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(DailyNoteRecord {
+                note_date: row.get::<_, String>(0)?,
+                node_id: node_id_from_row(row, 1)?,
+            })
+        })
+        .map_err(map_sqlite_error)?;
+
+    let mut daily_notes = Vec::new();
+    for row in rows {
+        daily_notes.push(row.map_err(map_sqlite_error)?);
+    }
+    Ok(daily_notes)
+}
+
+fn is_daily_note_node_in_handle(handle: &impl SqlHandle, node_id: NodeId) -> KernelResult<bool> {
+    handle
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1
+                 FROM daily_notes
+                 WHERE node_id = ?1
+             )",
+            params![node_id.value()],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|exists| exists == 1)
+        .map_err(map_sqlite_error)
+}
+
+fn is_root_node_in_handle(handle: &impl SqlHandle, node_id: NodeId) -> KernelResult<bool> {
+    handle
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1
+                 FROM root_nodes
+                 WHERE node_id = ?1
+             )",
+            params![node_id.value()],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|exists| exists == 1)
+        .map_err(map_sqlite_error)
+}
+
+fn list_root_nodes_from_handle(handle: &impl SqlHandle) -> KernelResult<Vec<StoredNode>> {
+    let mut statement = handle
+        .prepare(
+            "SELECT node_id
+             FROM root_nodes
+             ORDER BY node_id",
+        )
+        .map_err(map_sqlite_error)?;
+    let rows = statement
+        .query_map([], |row| node_id_from_row(row, 0))
+        .map_err(map_sqlite_error)?;
+
+    let mut nodes = Vec::new();
+    for row in rows {
+        let node_id = row.map_err(map_sqlite_error)?;
+        let node = fetch_node(handle, node_id)?.ok_or(KernelError::StorageCorruption(format!(
+            "missing root node {node_id}"
+        )))?;
+        nodes.push(node);
+    }
+    Ok(nodes)
+}
+
+fn find_root_node_by_content_from_handle(
+    handle: &impl SqlHandle,
+    content: &ContentLine,
+) -> KernelResult<Option<StoredNode>> {
+    handle
+        .query_row(
+            "SELECT n.id
+             FROM root_nodes AS r
+             JOIN nodes AS n
+               ON n.id = r.node_id
+             WHERE n.content = ?1
+             ORDER BY n.id
+             LIMIT 1",
+            params![content.as_str()],
+            |row| node_id_from_row(row, 0),
+        )
+        .optional()
+        .map_err(map_sqlite_error)?
+        .map(|node_id| {
+            fetch_node(handle, node_id)?.ok_or(KernelError::StorageCorruption(format!(
+                "missing root node {node_id}"
+            )))
+        })
+        .transpose()
+}
+
+fn search_text_matches_from_handle(
+    handle: &impl SqlHandle,
+    needle: &str,
+) -> KernelResult<Vec<StoredNode>> {
+    let mut statement = handle
+        .prepare(
+            "SELECT n.id
+             FROM nodes AS n
+             LEFT JOIN root_nodes AS r
+               ON r.node_id = n.id
+             LEFT JOIN daily_notes AS d
+               ON d.node_id = n.id
+             WHERE r.node_id IS NULL
+               AND d.node_id IS NULL
+               AND instr(n.content, ?1) > 0
+             ORDER BY n.id",
+        )
+        .map_err(map_sqlite_error)?;
+    let rows = statement
+        .query_map(params![needle], |row| node_id_from_row(row, 0))
+        .map_err(map_sqlite_error)?;
+
+    let mut nodes = Vec::new();
+    for row in rows {
+        let node_id = row.map_err(map_sqlite_error)?;
+        let node = fetch_node(handle, node_id)?.ok_or(KernelError::StorageCorruption(format!(
+            "missing search match node {node_id}"
+        )))?;
+        nodes.push(node);
+    }
+    Ok(nodes)
 }
 
 fn list_outgoing_links_from_handle(
@@ -1082,6 +1501,31 @@ fn insert_single_node(
     insert_aliases(transaction, node_id, &node.aliases)?;
     refresh_outgoing_links(transaction, node_id, &node.outgoing_links)?;
     attach_chain(transaction, node_id, node_id, placement)?;
+    Ok(node_id)
+}
+
+fn insert_top_level_node(
+    transaction: &Transaction<'_>,
+    node: &NewNodeRecord,
+) -> KernelResult<NodeId> {
+    transaction
+        .execute(
+            "INSERT INTO nodes (
+                content,
+                content_lookup_key,
+                parent_id,
+                first_child_id,
+                last_child_id,
+                prev_sibling_id,
+                next_sibling_id
+             ) VALUES (?1, ?2, NULL, NULL, NULL, NULL, NULL)",
+            params![node.content.as_str(), node.lookup_key.as_str()],
+        )
+        .map_err(map_sqlite_error)?;
+    let node_id = NodeId::try_from(transaction.last_insert_rowid())
+        .map_err(|error| KernelError::Storage(error.to_string()))?;
+    insert_aliases(transaction, node_id, &node.aliases)?;
+    refresh_outgoing_links(transaction, node_id, &node.outgoing_links)?;
     Ok(node_id)
 }
 
@@ -1213,6 +1657,15 @@ fn validate_placement_target(
     placement: Placement,
     moving_node_id: Option<NodeId>,
 ) -> KernelResult<()> {
+    if matches!(
+        placement,
+        Placement::TopLevelFirst | Placement::TopLevelLast
+    ) {
+        return Err(KernelError::Input(String::from(
+            "top-level placement is not supported",
+        )));
+    }
+
     if let Some(target_id) = placement.target_id() {
         ensure_node_exists_in_db(handle, target_id)?;
         if Some(target_id) == moving_node_id {
@@ -1257,21 +1710,17 @@ fn is_in_subtree(
 }
 
 fn detach_node(transaction: &Transaction<'_>, node: &StoredNode) -> KernelResult<()> {
-    let (current_first, current_last) = match node.parent_id {
-        Some(parent_id) => {
-            let parent = fetch_node(transaction, parent_id)?.ok_or(
-                KernelError::StorageCorruption(format!(
-                    "missing parent node {parent_id} while detaching {}",
-                    node.id
-                )),
-            )?;
-            (parent.first_child_id, parent.last_child_id)
-        }
-        None => {
-            let root = fetch_root(transaction)?;
-            (root.first_child_id, root.last_child_id)
-        }
-    };
+    let parent_id = node.parent_id.ok_or(KernelError::Constraint(format!(
+        "top-level node {} cannot be detached",
+        node.id
+    )))?;
+    let parent =
+        fetch_node(transaction, parent_id)?.ok_or(KernelError::StorageCorruption(format!(
+            "missing parent node {parent_id} while detaching {}",
+            node.id
+        )))?;
+    let current_first = parent.first_child_id;
+    let current_last = parent.last_child_id;
 
     let new_first = if node.prev_sibling_id.is_none() {
         node.next_sibling_id
@@ -1311,7 +1760,7 @@ fn detach_node(transaction: &Transaction<'_>, node: &StoredNode) -> KernelResult
             .map_err(map_sqlite_error)?;
     }
 
-    set_container_bounds(transaction, node.parent_id, new_first, new_last)?;
+    set_container_bounds(transaction, Some(parent_id), new_first, new_last)?;
 
     transaction
         .execute(
@@ -1332,100 +1781,20 @@ fn attach_chain(
     placement: Placement,
 ) -> KernelResult<()> {
     match placement {
-        Placement::TopLevelFirst => {
-            let root = fetch_root(transaction)?;
-            update_chain_parent(transaction, first_id, last_id, None)?;
-            transaction
-                .execute(
-                    "UPDATE nodes
-                     SET prev_sibling_id = NULL
-                     WHERE id = ?1",
-                    params![first_id.value()],
-                )
-                .map_err(map_sqlite_error)?;
-            transaction
-                .execute(
-                    "UPDATE nodes
-                     SET next_sibling_id = ?1
-                     WHERE id = ?2",
-                    params![root.first_child_id.map(NodeId::value), last_id.value()],
-                )
-                .map_err(map_sqlite_error)?;
-            if let Some(old_first_id) = root.first_child_id {
-                transaction
-                    .execute(
-                        "UPDATE nodes
-                         SET prev_sibling_id = ?1
-                         WHERE id = ?2",
-                        params![last_id.value(), old_first_id.value()],
-                    )
-                    .map_err(map_sqlite_error)?;
-                transaction
-                    .execute(
-                        "UPDATE nodes
-                         SET next_sibling_id = ?1
-                         WHERE id = ?2",
-                        params![old_first_id.value(), last_id.value()],
-                    )
-                    .map_err(map_sqlite_error)?;
-            }
-            set_container_bounds(
-                transaction,
-                None,
-                Some(first_id),
-                root.last_child_id.or(Some(last_id)),
-            )?;
-        }
-        Placement::TopLevelLast => {
-            let root = fetch_root(transaction)?;
-            update_chain_parent(transaction, first_id, last_id, None)?;
-            transaction
-                .execute(
-                    "UPDATE nodes
-                     SET next_sibling_id = NULL
-                     WHERE id = ?1",
-                    params![last_id.value()],
-                )
-                .map_err(map_sqlite_error)?;
-            transaction
-                .execute(
-                    "UPDATE nodes
-                     SET prev_sibling_id = ?1
-                     WHERE id = ?2",
-                    params![root.last_child_id.map(NodeId::value), first_id.value()],
-                )
-                .map_err(map_sqlite_error)?;
-            if let Some(old_last_id) = root.last_child_id {
-                transaction
-                    .execute(
-                        "UPDATE nodes
-                         SET next_sibling_id = ?1
-                         WHERE id = ?2",
-                        params![first_id.value(), old_last_id.value()],
-                    )
-                    .map_err(map_sqlite_error)?;
-                transaction
-                    .execute(
-                        "UPDATE nodes
-                         SET prev_sibling_id = ?1
-                         WHERE id = ?2",
-                        params![old_last_id.value(), first_id.value()],
-                    )
-                    .map_err(map_sqlite_error)?;
-            }
-            set_container_bounds(
-                transaction,
-                None,
-                root.first_child_id.or(Some(first_id)),
-                Some(last_id),
-            )?;
+        Placement::TopLevelFirst | Placement::TopLevelLast => {
+            return Err(KernelError::Input(String::from(
+                "top-level placement is not supported",
+            )));
         }
         Placement::Before(target_id) => {
             let target = fetch_node(transaction, target_id)?.ok_or(KernelError::NotFound {
                 entity: "node",
                 id: target_id,
             })?;
-            update_chain_parent(transaction, first_id, last_id, target.parent_id)?;
+            let target_parent_id = target.parent_id.ok_or(KernelError::Constraint(format!(
+                "top-level node {target_id} cannot participate in sibling placement"
+            )))?;
+            update_chain_parent(transaction, first_id, last_id, Some(target_parent_id))?;
             transaction
                 .execute(
                     "UPDATE nodes
@@ -1452,17 +1821,17 @@ fn attach_chain(
                     )
                     .map_err(map_sqlite_error)?;
             } else {
-                let current_last = match target.parent_id {
-                    Some(parent_id) => {
-                        fetch_node(transaction, parent_id)?
-                            .ok_or(KernelError::StorageCorruption(format!(
-                                "missing parent node {parent_id}"
-                            )))?
-                            .last_child_id
-                    }
-                    None => fetch_root(transaction)?.last_child_id,
-                };
-                set_container_bounds(transaction, target.parent_id, Some(first_id), current_last)?;
+                let current_last = fetch_node(transaction, target_parent_id)?
+                    .ok_or(KernelError::StorageCorruption(format!(
+                        "missing parent node {target_parent_id}"
+                    )))?
+                    .last_child_id;
+                set_container_bounds(
+                    transaction,
+                    Some(target_parent_id),
+                    Some(first_id),
+                    current_last,
+                )?;
             }
             transaction
                 .execute(
@@ -1478,7 +1847,10 @@ fn attach_chain(
                 entity: "node",
                 id: target_id,
             })?;
-            update_chain_parent(transaction, first_id, last_id, target.parent_id)?;
+            let target_parent_id = target.parent_id.ok_or(KernelError::Constraint(format!(
+                "top-level node {target_id} cannot participate in sibling placement"
+            )))?;
+            update_chain_parent(transaction, first_id, last_id, Some(target_parent_id))?;
             transaction
                 .execute(
                     "UPDATE nodes
@@ -1505,17 +1877,17 @@ fn attach_chain(
                     )
                     .map_err(map_sqlite_error)?;
             } else {
-                let current_first = match target.parent_id {
-                    Some(parent_id) => {
-                        fetch_node(transaction, parent_id)?
-                            .ok_or(KernelError::StorageCorruption(format!(
-                                "missing parent node {parent_id}"
-                            )))?
-                            .first_child_id
-                    }
-                    None => fetch_root(transaction)?.first_child_id,
-                };
-                set_container_bounds(transaction, target.parent_id, current_first, Some(last_id))?;
+                let current_first = fetch_node(transaction, target_parent_id)?
+                    .ok_or(KernelError::StorageCorruption(format!(
+                        "missing parent node {target_parent_id}"
+                    )))?
+                    .first_child_id;
+                set_container_bounds(
+                    transaction,
+                    Some(target_parent_id),
+                    current_first,
+                    Some(last_id),
+                )?;
             }
             transaction
                 .execute(
@@ -1659,37 +2031,22 @@ fn set_container_bounds(
     first_child_id: Option<NodeId>,
     last_child_id: Option<NodeId>,
 ) -> KernelResult<()> {
-    match parent_id {
-        Some(parent_id) => {
-            transaction
-                .execute(
-                    "UPDATE nodes
-                     SET first_child_id = ?1,
-                         last_child_id = ?2
-                     WHERE id = ?3",
-                    params![
-                        first_child_id.map(NodeId::value),
-                        last_child_id.map(NodeId::value),
-                        parent_id.value()
-                    ],
-                )
-                .map_err(map_sqlite_error)?;
-        }
-        None => {
-            transaction
-                .execute(
-                    "UPDATE tree_root
-                     SET first_child_id = ?1,
-                         last_child_id = ?2
-                     WHERE root_id = 1",
-                    params![
-                        first_child_id.map(NodeId::value),
-                        last_child_id.map(NodeId::value)
-                    ],
-                )
-                .map_err(map_sqlite_error)?;
-        }
-    }
+    let parent_id = parent_id.ok_or(KernelError::Constraint(String::from(
+        "top-level nodes do not own child-chain bounds",
+    )))?;
+    transaction
+        .execute(
+            "UPDATE nodes
+             SET first_child_id = ?1,
+                 last_child_id = ?2
+             WHERE id = ?3",
+            params![
+                first_child_id.map(NodeId::value),
+                last_child_id.map(NodeId::value),
+                parent_id.value()
+            ],
+        )
+        .map_err(map_sqlite_error)?;
     Ok(())
 }
 
@@ -1759,8 +2116,11 @@ fn find_external_subtree_reference(
 mod tests {
     use tempfile::NamedTempFile;
 
-    use memoryroam_domain::{DeleteMode, Placement};
-    use memoryroam_read::{list_top_level, read_node};
+    use memoryroam_domain::{
+        ContentLine, DeleteMode, NewNodeRecord, Placement, ReadRepository, WriteRepository,
+        canonicalize_content,
+    };
+    use memoryroam_read::read_node;
     use memoryroam_write::{add_aliases, create_nodes, delete_node, init, move_node, update_node};
 
     use super::*;
@@ -1774,101 +2134,135 @@ mod tests {
         SqliteStore::open_or_create(path).expect("store should open")
     }
 
-    #[test]
-    fn init_schema_creates_tree_root() {
-        let mut store = store();
-
-        init(&mut store).expect("schema init should succeed");
-        let root = fetch_root(&store.connection).expect("root row should exist");
-
-        assert_eq!(root.first_child_id, None);
-        assert_eq!(root.last_child_id, None);
+    fn node_record(repository: &impl ReadRepository, raw_content: &str) -> NewNodeRecord {
+        let content = ContentLine::parse(raw_content).expect("content should parse");
+        let canonical =
+            canonicalize_content(repository, &content).expect("content should canonicalize");
+        NewNodeRecord {
+            content: canonical.content,
+            lookup_key: canonical.lookup_key,
+            outgoing_links: canonical.outgoing_links,
+            aliases: Vec::new(),
+        }
     }
 
     #[test]
-    fn create_and_read_round_trip_with_lookup_canonicalization() {
+    fn init_schema_starts_with_empty_root_and_daily_note_sets() {
+        let mut store = store();
+
+        init(&mut store).expect("schema init should succeed");
+        assert!(
+            store
+                .list_root_nodes()
+                .expect("root list should load")
+                .is_empty()
+        );
+        assert!(
+            store
+                .list_daily_notes()
+                .expect("daily notes should load")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn root_nodes_participate_in_lookup_resolution() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        create_nodes(&mut store, "Topic", &[], Placement::TopLevelLast)
-            .expect("first create should succeed");
-        add_aliases(
+        let root_id = store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect("root node should be created");
+        add_aliases(&mut store, root_id, &[String::from("topic")])
+            .expect("alias add should succeed");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+        create_nodes(
             &mut store,
-            NodeId::new(1).expect("valid id"),
-            &[String::from("topic")],
+            "See {{topic}}",
+            &[],
+            Placement::LastChildOf(day_node_id),
         )
-        .expect("alias add should succeed");
-        create_nodes(&mut store, "See {{topic}}", &[], Placement::TopLevelLast)
-            .expect("lookup create should succeed");
+        .expect("lookup create should succeed");
 
-        let view =
-            read_node(&store, NodeId::new(2).expect("valid id")).expect("read should succeed");
+        let child_id = NodeId::new(day_node_id.value() + 1).expect("valid id");
+        let view = read_node(&store, child_id).expect("read should succeed");
 
-        assert_eq!(view.node.rendered_content, "See {{1::topic}}");
-        let incoming =
-            read_node(&store, NodeId::new(1).expect("valid id")).expect("read should succeed");
+        assert_eq!(
+            view.node.rendered_content,
+            format!("See {{{{{root_id}::topic}}}}")
+        );
+        let incoming = read_node(&store, root_id).expect("read should succeed");
         assert_eq!(incoming.incoming_links.len(), 1);
     }
 
     #[test]
-    fn batch_create_prefers_earlier_lines_over_existing_duplicates() {
+    fn daily_note_nodes_are_immutable() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        create_nodes(&mut store, "Topic", &[], Placement::TopLevelLast)
-            .expect("existing topic should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
 
-        create_nodes(
-            &mut store,
-            "Topic\nSee {{Topic}}",
-            &[],
-            Placement::TopLevelLast,
-        )
-        .expect("batch create should prefer the earlier line in the same batch");
+        let update_error =
+            update_node(&mut store, day_node_id, "2026-04-12").expect_err("update should fail");
+        assert!(matches!(update_error, KernelError::Constraint(_)));
 
-        let view =
-            read_node(&store, NodeId::new(3).expect("valid id")).expect("read should succeed");
+        let alias_error = add_aliases(&mut store, day_node_id, &[String::from("today")])
+            .expect_err("alias add should fail");
+        assert!(matches!(alias_error, KernelError::Constraint(_)));
 
-        assert_eq!(view.node.rendered_content, "See {{2::Topic}}");
+        let delete_error = delete_node(&mut store, day_node_id, DeleteMode::Cascade)
+            .expect_err("delete should fail");
+        assert!(matches!(delete_error, KernelError::Constraint(_)));
     }
 
     #[test]
-    fn move_preserves_top_level_order() {
+    fn move_preserves_child_order_within_a_parent() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        create_nodes(&mut store, "A\nB\nC", &[], Placement::TopLevelLast)
-            .expect("create should succeed");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+        create_nodes(&mut store, "A", &[], Placement::LastChildOf(day_node_id)).expect("create A");
+        create_nodes(&mut store, "B", &[], Placement::LastChildOf(day_node_id)).expect("create B");
+        create_nodes(&mut store, "C", &[], Placement::LastChildOf(day_node_id)).expect("create C");
 
         move_node(
             &mut store,
-            NodeId::new(3).expect("valid id"),
-            Placement::Before(NodeId::new(1).expect("valid id")),
+            NodeId::new(day_node_id.value() + 2).expect("valid id"),
+            Placement::After(NodeId::new(day_node_id.value() + 3).expect("valid id")),
         )
         .expect("move should succeed");
 
-        let entries = list_top_level(&store).expect("list should succeed");
-        assert_eq!(
-            entries
-                .iter()
-                .map(|entry| entry.rendered_content.clone())
-                .collect::<Vec<_>>(),
-            vec![String::from("C"), String::from("A"), String::from("B")]
-        );
+        let entries = store
+            .list_children(Some(day_node_id))
+            .expect("children should list");
+        assert_eq!(entries[0].content.as_str(), "A");
+        assert_eq!(entries[1].content.as_str(), "C");
+        assert_eq!(entries[2].content.as_str(), "B");
     }
 
     #[test]
     fn delete_rejects_referenced_node() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        create_nodes(&mut store, "Topic", &[], Placement::TopLevelLast)
-            .expect("first create should succeed");
-        create_nodes(&mut store, "Ref {{1}}", &[], Placement::TopLevelLast)
-            .expect("create should succeed");
-
-        let error = delete_node(
+        let root_id = store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect("root node should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+        create_nodes(
             &mut store,
-            NodeId::new(1).expect("valid id"),
-            DeleteMode::Cascade,
+            &format!("Ref {{{{{root_id}}}}}"),
+            &[],
+            Placement::LastChildOf(day_node_id),
         )
-        .expect_err("delete should fail when incoming links exist");
+        .expect("create should succeed");
+
+        let error = delete_node(&mut store, root_id, DeleteMode::Cascade)
+            .expect_err("delete should fail when incoming links exist");
 
         assert!(matches!(error, KernelError::Constraint(_)));
     }
@@ -1877,26 +2271,24 @@ mod tests {
     fn cascade_delete_allows_internal_subtree_references() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        create_nodes(&mut store, "Root", &[], Placement::TopLevelLast)
+        let root_id = store
+            .create_root_node(&node_record(&store, "Root"))
             .expect("root create should succeed");
         create_nodes(
             &mut store,
             "Child {{1}}",
             &[],
-            Placement::LastChildOf(NodeId::new(1).expect("valid id")),
+            Placement::LastChildOf(root_id),
         )
         .expect("child create should succeed");
 
-        delete_node(
-            &mut store,
-            NodeId::new(1).expect("valid id"),
-            DeleteMode::Cascade,
-        )
-        .expect("cascade delete should ignore internal subtree references");
+        delete_node(&mut store, root_id, DeleteMode::Cascade)
+            .expect("cascade delete should ignore internal subtree references");
 
         assert!(
-            list_top_level(&store)
-                .expect("list should succeed")
+            store
+                .list_root_nodes()
+                .expect("root list should load")
                 .is_empty()
         );
     }
@@ -1905,45 +2297,47 @@ mod tests {
     fn update_refreshes_outgoing_links() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        create_nodes(&mut store, "Target\nSource", &[], Placement::TopLevelLast)
-            .expect("create should succeed");
-
-        update_node(
+        let root_id = store
+            .create_root_node(&node_record(&store, "Target"))
+            .expect("root node should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+        create_nodes(
             &mut store,
-            NodeId::new(2).expect("valid id"),
-            "Source {{1}}",
+            "Source",
+            &[],
+            Placement::LastChildOf(day_node_id),
         )
-        .expect("update should succeed");
+        .expect("create should succeed");
+        let source_id = NodeId::new(day_node_id.value() + 1).expect("valid id");
+
+        update_node(&mut store, source_id, &format!("Source {{{{{root_id}}}}}"))
+            .expect("update should succeed");
 
         let incoming = store
-            .list_incoming_links(NodeId::new(1).expect("valid id"))
+            .list_incoming_links(root_id)
             .expect("incoming links should load");
         assert_eq!(incoming.len(), 1);
-        assert_eq!(
-            incoming[0].source_node_id,
-            NodeId::new(2).expect("valid id")
-        );
+        assert_eq!(incoming[0].source_node_id, source_id);
     }
 
     #[test]
     fn alias_remove_uses_trimmed_lookup_key() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        create_nodes(&mut store, "Topic", &[], Placement::TopLevelLast)
+        let root_id = store
+            .create_root_node(&node_record(&store, "Topic"))
             .expect("create should succeed");
-        add_aliases(
-            &mut store,
-            NodeId::new(1).expect("valid id"),
-            &[String::from(" topic ")],
-        )
-        .expect("alias add should succeed");
+        add_aliases(&mut store, root_id, &[String::from(" topic ")])
+            .expect("alias add should succeed");
 
-        memoryroam_write::remove_alias(&mut store, NodeId::new(1).expect("valid id"), "topic")
+        memoryroam_write::remove_alias(&mut store, root_id, "topic")
             .expect("trimmed alias removal should succeed");
 
         assert!(
             store
-                .list_aliases(NodeId::new(1).expect("valid id"))
+                .list_aliases(root_id)
                 .expect("aliases should load")
                 .is_empty()
         );
@@ -1953,16 +2347,24 @@ mod tests {
     fn node_path_uses_rendered_content() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        create_nodes(&mut store, "Leaf", &[], Placement::TopLevelLast)
+        let parent_id = store
+            .create_daily_note_node("2026-04-11")
             .expect("first create should succeed");
         create_nodes(&mut store, "Parent {{1}}", &[], Placement::TopLevelLast)
-            .expect("second create should succeed");
+            .expect_err("top-level placement should be rejected");
+        create_nodes(
+            &mut store,
+            "Child {{1}}",
+            &[],
+            Placement::LastChildOf(parent_id),
+        )
+        .expect("child create should succeed");
 
         assert_eq!(
             store
-                .node_path(NodeId::new(2).expect("valid id"))
+                .node_path(NodeId::new(parent_id.value() + 1).expect("valid id"))
                 .expect("path should load"),
-            "Parent {{1::>Leaf}}"
+            "2026-04-11 > Child {{1::>2026-04-11}}"
         );
     }
 }

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -196,7 +196,10 @@ WHEN EXISTS (
         EXISTS (
         SELECT 1
         FROM nodes AS existing
+        LEFT JOIN daily_notes AS note
+          ON note.node_id = existing.id
         WHERE existing.id <> NEW.node_id
+          AND note.node_id IS NULL
           AND existing.content_lookup_key = incoming.content_lookup_key
     )
        OR EXISTS (
@@ -221,7 +224,10 @@ WHEN EXISTS (
 AND EXISTS (
     SELECT 1
     FROM nodes AS existing
+    LEFT JOIN daily_notes AS note
+      ON note.node_id = existing.id
     WHERE existing.id <> OLD.id
+      AND note.node_id IS NULL
       AND existing.content_lookup_key = NEW.content_lookup_key
     UNION ALL
     SELECT 1
@@ -2993,6 +2999,20 @@ mod tests {
             .create_root_node(&node_record(&store, "Topic"))
             .expect_err("root should reject alias-owned lookup key");
         assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn create_root_node_ignores_daily_note_date_nodes_for_lookup_ownership() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+
+        let root_id = store
+            .create_root_node(&node_record(&store, "2026-04-11"))
+            .expect("root should ignore daily note date nodes");
+        assert_eq!(root_id.value(), 2);
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -14,7 +14,8 @@ use memoryroam_domain::{
 };
 use rusqlite::types::Type;
 use rusqlite::{
-    Connection, ErrorCode, OpenFlags, OptionalExtension, Params, Row, Transaction, params,
+    Connection, ErrorCode, OpenFlags, OptionalExtension, Params, Row, Transaction,
+    TransactionBehavior, params,
 };
 
 const SCHEMA: &str = r#"
@@ -943,7 +944,10 @@ impl WriteRepository for SqliteStore {
         note_date: &str,
         node: &NewNodeRecord,
     ) -> KernelResult<NodeId> {
-        let transaction = self.connection.transaction().map_err(map_sqlite_error)?;
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(map_sqlite_error)?;
         ensure_schema_initialized(&transaction)?;
 
         let note_node_id = match find_daily_note_from_handle(&transaction, note_date)? {
@@ -1235,9 +1239,19 @@ impl ReadRepository for BatchCreateRepository<'_> {
     }
 
     fn lookup_candidates(&self, key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
+        let mut candidates = TransactionRepository {
+            transaction: self.transaction,
+        }
+        .lookup_candidates(key)?;
+
         if let Some(node_ids) = self.preferred_candidates.get(key) {
-            let mut candidates = Vec::with_capacity(node_ids.len());
             for node_id in node_ids {
+                if candidates
+                    .iter()
+                    .any(|candidate| candidate.node_id == *node_id)
+                {
+                    continue;
+                }
                 let node = fetch_node(self.transaction, *node_id)?.ok_or(
                     KernelError::StorageCorruption(format!("missing batch-created node {node_id}")),
                 )?;
@@ -1247,13 +1261,10 @@ impl ReadRepository for BatchCreateRepository<'_> {
                     path: self.node_path(*node_id)?,
                 });
             }
-            return Ok(candidates);
         }
 
-        TransactionRepository {
-            transaction: self.transaction,
-        }
-        .lookup_candidates(key)
+        candidates.sort_by_key(|candidate| candidate.node_id);
+        Ok(candidates)
     }
 
     fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
@@ -2707,6 +2718,27 @@ mod tests {
         );
         let incoming = read_node(&store, root_id).expect("read should succeed");
         assert_eq!(incoming.incoming_links.len(), 1);
+    }
+
+    #[test]
+    fn batch_create_keeps_existing_lookup_candidates_visible() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect("root node should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+
+        let error = create_nodes(
+            &mut store,
+            "Topic\nSee {{Topic}}",
+            &[],
+            Placement::LastChildOf(day_node_id),
+        )
+        .expect_err("ambiguous lookup should fail");
+        assert!(matches!(error, KernelError::LookupAmbiguous { .. }));
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -257,6 +257,183 @@ END;
 PRAGMA user_version = 2;
 "#;
 
+const LEGACY_MIGRATION_SCHEMA: &str = r#"
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS root_nodes (
+    node_id INTEGER PRIMARY KEY
+            REFERENCES nodes(id)
+            ON DELETE RESTRICT
+            DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS daily_notes (
+    note_date TEXT PRIMARY KEY,
+    node_id   INTEGER NOT NULL UNIQUE
+              REFERENCES nodes(id)
+              ON DELETE RESTRICT
+              DEFERRABLE INITIALLY DEFERRED,
+
+    CHECK (date(note_date) = note_date)
+);
+
+CREATE TABLE IF NOT EXISTS node_aliases (
+    node_id     INTEGER NOT NULL
+                REFERENCES nodes(id)
+                ON DELETE CASCADE
+                DEFERRABLE INITIALLY DEFERRED,
+
+    alias_text  TEXT NOT NULL,
+    alias_key   TEXT NOT NULL,
+
+    PRIMARY KEY (node_id, alias_text),
+    UNIQUE (node_id, alias_key)
+);
+
+CREATE TABLE IF NOT EXISTS node_links (
+    source_node_id  INTEGER NOT NULL
+                    REFERENCES nodes(id)
+                    ON DELETE CASCADE
+                    DEFERRABLE INITIALLY DEFERRED,
+
+    ordinal         INTEGER NOT NULL,
+    target_node_id  INTEGER NOT NULL
+                    REFERENCES nodes(id)
+                    DEFERRABLE INITIALLY DEFERRED,
+
+    PRIMARY KEY (source_node_id, ordinal)
+);
+
+CREATE INDEX IF NOT EXISTS idx_daily_notes_node_id
+    ON daily_notes(node_id);
+
+CREATE INDEX IF NOT EXISTS idx_aliases_alias_key
+    ON node_aliases(alias_key, node_id);
+
+CREATE INDEX IF NOT EXISTS idx_links_target_source
+    ON node_links(target_node_id, source_node_id, ordinal);
+
+CREATE VIEW IF NOT EXISTS v_lookup_candidates AS
+SELECT
+    id AS node_id,
+    content_lookup_key AS lookup_key,
+    'content' AS match_kind
+FROM nodes
+WHERE id NOT IN (SELECT node_id FROM daily_notes)
+UNION ALL
+SELECT
+    a.node_id,
+    alias_key AS lookup_key,
+    'alias' AS match_kind
+FROM node_aliases AS a
+WHERE a.node_id NOT IN (SELECT node_id FROM daily_notes);
+
+CREATE VIEW IF NOT EXISTS v_incoming_links AS
+SELECT
+    l.target_node_id,
+    l.source_node_id,
+    s.content AS source_content,
+    l.ordinal
+FROM node_links AS l
+JOIN nodes AS s
+  ON s.id = l.source_node_id;
+
+CREATE TRIGGER IF NOT EXISTS root_nodes_validate_insert
+BEFORE INSERT ON root_nodes
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'root node must be a top-level node without siblings')
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM nodes
+        WHERE id = NEW.node_id
+          AND parent_id IS NULL
+          AND prev_sibling_id IS NULL
+          AND next_sibling_id IS NULL
+    );
+
+    SELECT RAISE(ABORT, 'root node cannot also be a daily note')
+    WHERE EXISTS (
+        SELECT 1
+        FROM daily_notes
+        WHERE node_id = NEW.node_id
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert
+BEFORE INSERT ON daily_notes
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'daily note node must be a top-level node without siblings')
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM nodes
+        WHERE id = NEW.node_id
+          AND parent_id IS NULL
+          AND prev_sibling_id IS NULL
+          AND next_sibling_id IS NULL
+          AND content = NEW.note_date
+    );
+
+    SELECT RAISE(ABORT, 'daily note node cannot also be a root node')
+    WHERE EXISTS (
+        SELECT 1
+        FROM root_nodes
+        WHERE node_id = NEW.node_id
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS daily_note_nodes_reject_update
+BEFORE UPDATE OF content, parent_id, prev_sibling_id, next_sibling_id ON nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM daily_notes
+    WHERE node_id = OLD.id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'daily note date nodes are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS daily_note_nodes_reject_delete
+BEFORE DELETE ON nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM daily_notes
+    WHERE node_id = OLD.id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'daily note date nodes are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS node_aliases_reject_daily_note_insert
+BEFORE INSERT ON node_aliases
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM daily_notes
+    WHERE node_id = NEW.node_id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'daily note date nodes cannot have aliases');
+END;
+
+CREATE TRIGGER IF NOT EXISTS node_aliases_reject_daily_note_delete
+BEFORE DELETE ON node_aliases
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM daily_notes
+    WHERE node_id = OLD.node_id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'daily note date nodes cannot have aliases');
+END;
+
+PRAGMA user_version = 2;
+"#;
+
 /// SQLite-backed repository implementation for MemoryRoam.
 #[derive(Debug)]
 pub struct SqliteStore {
@@ -506,6 +683,7 @@ impl WriteRepository for SqliteStore {
                 .connection
                 .execute_batch(SCHEMA)
                 .map_err(map_sqlite_error),
+            1 => migrate_v1_schema(&mut self.connection),
             2 => Ok(()),
             other => Err(KernelError::Storage(format!(
                 "unsupported schema version {other}; rebuild the database for schema v2"
@@ -1239,6 +1417,57 @@ fn ensure_schema_initialized(handle: &impl SqlHandle) -> KernelResult<()> {
     Ok(())
 }
 
+fn migrate_v1_schema(connection: &mut Connection) -> KernelResult<()> {
+    let transaction = connection.transaction().map_err(map_sqlite_error)?;
+    transaction
+        .execute_batch(LEGACY_MIGRATION_SCHEMA)
+        .map_err(map_sqlite_error)?;
+
+    let mut current = transaction
+        .query_row(
+            "SELECT first_child_id
+             FROM tree_root
+             WHERE root_id = 1",
+            [],
+            |row| optional_node_id_from_row(row, 0),
+        )
+        .optional()
+        .map_err(map_sqlite_error)?
+        .flatten();
+
+    let mut root_node_ids = Vec::new();
+    while let Some(node_id) = current {
+        let node = fetch_node(&transaction, node_id)?.ok_or(KernelError::StorageCorruption(
+            format!("missing legacy root node {node_id}"),
+        ))?;
+        current = node.next_sibling_id;
+        root_node_ids.push(node_id);
+    }
+
+    for node_id in &root_node_ids {
+        transaction
+            .execute(
+                "UPDATE nodes
+                 SET prev_sibling_id = NULL,
+                     next_sibling_id = NULL
+                 WHERE id = ?1",
+                params![node_id.value()],
+            )
+            .map_err(map_sqlite_error)?;
+    }
+
+    for node_id in root_node_ids {
+        transaction
+            .execute(
+                "INSERT OR IGNORE INTO root_nodes (node_id) VALUES (?1)",
+                params![node_id.value()],
+            )
+            .map_err(map_sqlite_error)?;
+    }
+
+    transaction.commit().map_err(map_sqlite_error)
+}
+
 fn map_sqlite_error(error: rusqlite::Error) -> KernelError {
     match error {
         rusqlite::Error::QueryReturnedNoRows => KernelError::Storage(String::from("row not found")),
@@ -1410,8 +1639,7 @@ fn find_root_node_by_content_from_handle(
     handle: &impl SqlHandle,
     content: &ContentLine,
 ) -> KernelResult<Option<StoredNode>> {
-    let lookup_key =
-        LookupKey::from_content(content).map_err(|error| KernelError::Input(error.to_string()))?;
+    let lookup_key = content.as_str().trim();
     handle
         .query_row(
             "SELECT n.id
@@ -1421,7 +1649,7 @@ fn find_root_node_by_content_from_handle(
              WHERE n.content_lookup_key = ?1
              ORDER BY n.id
              LIMIT 1",
-            params![lookup_key.as_str()],
+            params![lookup_key],
             |row| node_id_from_row(row, 0),
         )
         .optional()
@@ -2179,16 +2407,44 @@ mod tests {
     }
 
     #[test]
-    fn init_schema_rejects_legacy_schema_versions() {
+    fn init_schema_migrates_legacy_root_nodes() {
         let mut store = store();
 
-        store
-            .connection
-            .execute_batch("PRAGMA user_version = 1;")
-            .expect("legacy version should be set");
+        store.connection.execute_batch(
+            r#"
+            PRAGMA user_version = 1;
+            CREATE TABLE nodes (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                content             TEXT NOT NULL,
+                content_lookup_key  TEXT NOT NULL,
+                parent_id           INTEGER REFERENCES nodes(id),
+                first_child_id      INTEGER REFERENCES nodes(id),
+                last_child_id       INTEGER REFERENCES nodes(id),
+                prev_sibling_id     INTEGER REFERENCES nodes(id),
+                next_sibling_id     INTEGER REFERENCES nodes(id)
+            );
+            CREATE TABLE tree_root (
+                root_id         INTEGER PRIMARY KEY,
+                first_child_id  INTEGER REFERENCES nodes(id),
+                last_child_id   INTEGER REFERENCES nodes(id)
+            );
+            INSERT INTO nodes(id, content, content_lookup_key, parent_id, first_child_id, last_child_id, prev_sibling_id, next_sibling_id)
+            VALUES
+                (1, 'Topic', 'Topic', NULL, NULL, NULL, NULL, 2),
+                (2, 'Other', 'Other', NULL, NULL, NULL, 1, NULL);
+            INSERT INTO tree_root(root_id, first_child_id, last_child_id) VALUES (1, 1, 2);
+            "#,
+        )
+        .expect("legacy schema should be created");
 
-        let error = init(&mut store).expect_err("legacy schema should be rejected");
-        assert!(matches!(error, KernelError::Storage(_)));
+        init(&mut store).expect("legacy schema should migrate");
+
+        let roots = store.list_root_nodes().expect("root nodes should load");
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots[0].content.as_str(), "Topic");
+        assert_eq!(roots[1].content.as_str(), "Other");
+        assert!(roots.iter().all(|node| node.prev_sibling_id.is_none()));
+        assert!(roots.iter().all(|node| node.next_sibling_id.is_none()));
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -182,18 +182,6 @@ BEGIN
         FROM daily_notes
         WHERE node_id = NEW.node_id
     );
-
-    SELECT RAISE(ABORT, 'root nodes cannot contain links')
-    WHERE EXISTS (
-        SELECT 1
-        FROM nodes
-        WHERE id = NEW.node_id
-          AND (
-              instr(content, '{{') > 0
-              OR instr(content, '}}') > 0
-              OR instr(content, '::') > 0
-          )
-    );
 END;
 
 CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key
@@ -230,269 +218,6 @@ AND EXISTS (
 )
 BEGIN
     SELECT RAISE(ABORT, 'duplicate root lookup key');
-END;
-
-CREATE TRIGGER IF NOT EXISTS root_nodes_reject_link_syntax_on_update
-BEFORE UPDATE OF content ON nodes
-FOR EACH ROW
-WHEN EXISTS (
-    SELECT 1
-    FROM root_nodes
-    WHERE node_id = OLD.id
-)
-AND (
-    instr(NEW.content, '{{') > 0
-    OR instr(NEW.content, '}}') > 0
-    OR instr(NEW.content, '::') > 0
-)
-BEGIN
-    SELECT RAISE(ABORT, 'root nodes cannot contain links');
-END;
-
-CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert
-BEFORE INSERT ON daily_notes
-FOR EACH ROW
-BEGIN
-    SELECT RAISE(ABORT, 'daily note node must be a top-level node without siblings')
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM nodes
-        WHERE id = NEW.node_id
-          AND parent_id IS NULL
-          AND prev_sibling_id IS NULL
-          AND next_sibling_id IS NULL
-          AND content = NEW.note_date
-    );
-
-    SELECT RAISE(ABORT, 'daily note node cannot also be a root node')
-    WHERE EXISTS (
-        SELECT 1
-        FROM root_nodes
-        WHERE node_id = NEW.node_id
-    );
-END;
-
-CREATE TRIGGER IF NOT EXISTS daily_note_nodes_reject_update
-BEFORE UPDATE OF content, parent_id, prev_sibling_id, next_sibling_id ON nodes
-FOR EACH ROW
-WHEN EXISTS (
-    SELECT 1
-    FROM daily_notes
-    WHERE node_id = OLD.id
-)
-BEGIN
-    SELECT RAISE(ABORT, 'daily note date nodes are immutable');
-END;
-
-CREATE TRIGGER IF NOT EXISTS daily_note_nodes_reject_delete
-BEFORE DELETE ON nodes
-FOR EACH ROW
-WHEN EXISTS (
-    SELECT 1
-    FROM daily_notes
-    WHERE node_id = OLD.id
-)
-BEGIN
-    SELECT RAISE(ABORT, 'daily note date nodes are immutable');
-END;
-
-CREATE TRIGGER IF NOT EXISTS node_aliases_reject_daily_note_insert
-BEFORE INSERT ON node_aliases
-FOR EACH ROW
-WHEN EXISTS (
-    SELECT 1
-    FROM daily_notes
-    WHERE node_id = NEW.node_id
-)
-BEGIN
-    SELECT RAISE(ABORT, 'daily note date nodes cannot have aliases');
-END;
-
-CREATE TRIGGER IF NOT EXISTS node_aliases_reject_daily_note_delete
-BEFORE DELETE ON node_aliases
-FOR EACH ROW
-WHEN EXISTS (
-    SELECT 1
-    FROM daily_notes
-    WHERE node_id = OLD.node_id
-)
-BEGIN
-    SELECT RAISE(ABORT, 'daily note date nodes cannot have aliases');
-END;
-
-PRAGMA user_version = 2;
-"#;
-
-const LEGACY_MIGRATION_SCHEMA: &str = r#"
-PRAGMA foreign_keys = ON;
-
-CREATE TABLE IF NOT EXISTS root_nodes (
-    node_id INTEGER PRIMARY KEY
-            REFERENCES nodes(id)
-            ON DELETE RESTRICT
-            DEFERRABLE INITIALLY DEFERRED,
-    sort_order INTEGER NOT NULL UNIQUE
-);
-
-DROP VIEW IF EXISTS v_lookup_candidates;
-DROP VIEW IF EXISTS v_incoming_links;
-
-CREATE TABLE IF NOT EXISTS daily_notes (
-    note_date TEXT PRIMARY KEY,
-    node_id   INTEGER NOT NULL UNIQUE
-              REFERENCES nodes(id)
-              ON DELETE RESTRICT
-              DEFERRABLE INITIALLY DEFERRED,
-
-    CHECK (date(note_date) = note_date)
-);
-
-CREATE TABLE IF NOT EXISTS node_aliases (
-    node_id     INTEGER NOT NULL
-                REFERENCES nodes(id)
-                ON DELETE CASCADE
-                DEFERRABLE INITIALLY DEFERRED,
-
-    alias_text  TEXT NOT NULL,
-    alias_key   TEXT NOT NULL,
-
-    PRIMARY KEY (node_id, alias_text),
-    UNIQUE (node_id, alias_key)
-);
-
-CREATE TABLE IF NOT EXISTS node_links (
-    source_node_id  INTEGER NOT NULL
-                    REFERENCES nodes(id)
-                    ON DELETE CASCADE
-                    DEFERRABLE INITIALLY DEFERRED,
-
-    ordinal         INTEGER NOT NULL,
-    target_node_id  INTEGER NOT NULL
-                    REFERENCES nodes(id)
-                    DEFERRABLE INITIALLY DEFERRED,
-
-    PRIMARY KEY (source_node_id, ordinal)
-);
-
-CREATE INDEX IF NOT EXISTS idx_daily_notes_node_id
-    ON daily_notes(node_id);
-
-CREATE INDEX IF NOT EXISTS idx_aliases_alias_key
-    ON node_aliases(alias_key, node_id);
-
-CREATE INDEX IF NOT EXISTS idx_links_target_source
-    ON node_links(target_node_id, source_node_id, ordinal);
-
-CREATE VIEW IF NOT EXISTS v_lookup_candidates AS
-SELECT
-    id AS node_id,
-    content_lookup_key AS lookup_key,
-    'content' AS match_kind
-FROM nodes
-WHERE id NOT IN (SELECT node_id FROM daily_notes)
-UNION ALL
-SELECT
-    a.node_id,
-    alias_key AS lookup_key,
-    'alias' AS match_kind
-FROM node_aliases AS a
-WHERE a.node_id NOT IN (SELECT node_id FROM daily_notes);
-
-CREATE VIEW IF NOT EXISTS v_incoming_links AS
-SELECT
-    l.target_node_id,
-    l.source_node_id,
-    s.content AS source_content,
-    l.ordinal
-FROM node_links AS l
-JOIN nodes AS s
-  ON s.id = l.source_node_id;
-
-CREATE TRIGGER IF NOT EXISTS root_nodes_validate_insert
-BEFORE INSERT ON root_nodes
-FOR EACH ROW
-BEGIN
-    SELECT RAISE(ABORT, 'root node must be a top-level node without siblings')
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM nodes
-        WHERE id = NEW.node_id
-          AND parent_id IS NULL
-          AND prev_sibling_id IS NULL
-          AND next_sibling_id IS NULL
-    );
-
-    SELECT RAISE(ABORT, 'root node cannot also be a daily note')
-    WHERE EXISTS (
-        SELECT 1
-        FROM daily_notes
-        WHERE node_id = NEW.node_id
-    );
-
-    SELECT RAISE(ABORT, 'root nodes cannot contain links')
-    WHERE EXISTS (
-        SELECT 1
-        FROM nodes
-        WHERE id = NEW.node_id
-          AND (
-              instr(content, '{{') > 0
-              OR instr(content, '}}') > 0
-              OR instr(content, '::') > 0
-          )
-    );
-END;
-
-CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key
-BEFORE INSERT ON root_nodes
-FOR EACH ROW
-WHEN EXISTS (
-    SELECT 1
-    FROM root_nodes AS r
-    JOIN nodes AS existing
-      ON existing.id = r.node_id
-    JOIN nodes AS incoming
-      ON incoming.id = NEW.node_id
-    WHERE existing.content_lookup_key = incoming.content_lookup_key
-)
-BEGIN
-    SELECT RAISE(ABORT, 'duplicate root lookup key');
-END;
-
-CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key_on_update
-BEFORE UPDATE OF content_lookup_key ON nodes
-FOR EACH ROW
-WHEN EXISTS (
-    SELECT 1
-    FROM root_nodes
-    WHERE node_id = OLD.id
-)
-AND EXISTS (
-    SELECT 1
-    FROM root_nodes AS r
-    JOIN nodes AS existing
-      ON existing.id = r.node_id
-    WHERE r.node_id <> OLD.id
-      AND existing.content_lookup_key = NEW.content_lookup_key
-)
-BEGIN
-    SELECT RAISE(ABORT, 'duplicate root lookup key');
-END;
-
-CREATE TRIGGER IF NOT EXISTS root_nodes_reject_link_syntax_on_update
-BEFORE UPDATE OF content ON nodes
-FOR EACH ROW
-WHEN EXISTS (
-    SELECT 1
-    FROM root_nodes
-    WHERE node_id = OLD.id
-)
-AND (
-    instr(NEW.content, '{{') > 0
-    OR instr(NEW.content, '}}') > 0
-    OR instr(NEW.content, '::') > 0
-)
-BEGIN
-    SELECT RAISE(ABORT, 'root nodes cannot contain links');
 END;
 
 CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert
@@ -818,10 +543,9 @@ impl WriteRepository for SqliteStore {
                 .connection
                 .execute_batch(SCHEMA)
                 .map_err(map_sqlite_error),
-            1 => migrate_v1_schema(&mut self.connection),
             2 => Ok(()),
             other => Err(KernelError::Storage(format!(
-                "unsupported schema version {other}; rebuild the database for schema v2"
+                "unsupported schema version {other}"
             ))),
         }
     }
@@ -1554,61 +1278,10 @@ fn ensure_schema_initialized(handle: &impl SqlHandle) -> KernelResult<()> {
         .map_err(map_sqlite_error)?;
     if version != 2 {
         return Err(KernelError::Storage(format!(
-            "unsupported schema version {version}; run `memoryroam init`"
+            "unsupported schema version {version}"
         )));
     }
     Ok(())
-}
-
-fn migrate_v1_schema(connection: &mut Connection) -> KernelResult<()> {
-    let transaction = connection.transaction().map_err(map_sqlite_error)?;
-    transaction
-        .execute_batch(LEGACY_MIGRATION_SCHEMA)
-        .map_err(map_sqlite_error)?;
-
-    let mut current = transaction
-        .query_row(
-            "SELECT first_child_id
-             FROM tree_root
-             WHERE root_id = 1",
-            [],
-            |row| optional_node_id_from_row(row, 0),
-        )
-        .optional()
-        .map_err(map_sqlite_error)?
-        .flatten();
-
-    let mut root_node_ids = Vec::new();
-    while let Some(node_id) = current {
-        let node = fetch_node(&transaction, node_id)?.ok_or(KernelError::StorageCorruption(
-            format!("missing legacy root node {node_id}"),
-        ))?;
-        current = node.next_sibling_id;
-        root_node_ids.push(node_id);
-    }
-
-    for node_id in &root_node_ids {
-        transaction
-            .execute(
-                "UPDATE nodes
-                 SET prev_sibling_id = NULL,
-                     next_sibling_id = NULL
-                 WHERE id = ?1",
-                params![node_id.value()],
-            )
-            .map_err(map_sqlite_error)?;
-    }
-
-    for (index, node_id) in root_node_ids.into_iter().enumerate() {
-        transaction
-            .execute(
-                "INSERT OR IGNORE INTO root_nodes (node_id, sort_order) VALUES (?1, ?2)",
-                params![node_id.value(), index as i64 + 1],
-            )
-            .map_err(map_sqlite_error)?;
-    }
-
-    transaction.commit().map_err(map_sqlite_error)
 }
 
 fn map_sqlite_error(error: rusqlite::Error) -> KernelError {
@@ -2599,7 +2272,7 @@ mod tests {
     }
 
     #[test]
-    fn init_schema_migrates_legacy_root_nodes() {
+    fn init_schema_rejects_legacy_schema_versions() {
         let mut store = store();
 
         store.connection.execute_batch(
@@ -2640,26 +2313,8 @@ mod tests {
         )
         .expect("legacy schema should be created");
 
-        init(&mut store).expect("legacy schema should migrate");
-
-        let roots = store.list_root_nodes().expect("root nodes should load");
-        assert_eq!(roots.len(), 3);
-        assert_eq!(roots[0].content.as_str(), "C");
-        assert_eq!(roots[1].content.as_str(), "A");
-        assert_eq!(roots[2].content.as_str(), "B");
-        assert!(roots.iter().all(|node| node.prev_sibling_id.is_none()));
-        assert!(roots.iter().all(|node| node.next_sibling_id.is_none()));
-
-        store
-            .create_daily_note_node("2026-04-11")
-            .expect("daily note should be created");
-        let key = LookupKey::new(String::from("2026-04-11")).expect("lookup key should parse");
-        assert!(
-            store
-                .lookup_candidates(&key)
-                .expect("lookup candidates should load")
-                .is_empty()
-        );
+        let error = init(&mut store).expect_err("legacy schema should be rejected");
+        assert!(matches!(error, KernelError::Storage(_)));
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -2251,14 +2251,35 @@ fn shift_root_sort_orders_from(
     if delta == 0 {
         return Ok(());
     }
-    transaction
-        .execute(
-            "UPDATE root_nodes
-             SET sort_order = sort_order + ?1
-             WHERE sort_order >= ?2",
-            params![delta, start_sort_order],
+    let mut statement = transaction
+        .prepare(
+            "SELECT node_id, sort_order
+             FROM root_nodes
+             WHERE sort_order >= ?1
+             ORDER BY sort_order DESC",
         )
         .map_err(map_sqlite_error)?;
+    let rows = statement
+        .query_map(params![start_sort_order], |row| {
+            Ok((node_id_from_row(row, 0)?, row.get::<_, i64>(1)?))
+        })
+        .map_err(map_sqlite_error)?;
+
+    let mut entries = Vec::new();
+    for row in rows {
+        entries.push(row.map_err(map_sqlite_error)?);
+    }
+
+    for (node_id, sort_order) in entries {
+        transaction
+            .execute(
+                "UPDATE root_nodes
+                 SET sort_order = ?1
+                 WHERE node_id = ?2",
+                params![sort_order + delta, node_id.value()],
+            )
+            .map_err(map_sqlite_error)?;
+    }
     Ok(())
 }
 
@@ -2275,16 +2296,56 @@ fn remove_top_level_nodes(transaction: &Transaction<'_>, node_ids: &[NodeId]) ->
     }
     sort_orders.sort_unstable();
     for removed_sort_order in sort_orders {
-        transaction
-            .execute(
-                "UPDATE root_nodes
-                 SET sort_order = sort_order - 1
-                 WHERE sort_order > ?1",
-                params![removed_sort_order],
+        let mut statement = transaction
+            .prepare(
+                "SELECT node_id, sort_order
+                 FROM root_nodes
+                 WHERE sort_order > ?1
+                 ORDER BY sort_order ASC",
             )
             .map_err(map_sqlite_error)?;
+        let rows = statement
+            .query_map(params![removed_sort_order], |row| {
+                Ok((node_id_from_row(row, 0)?, row.get::<_, i64>(1)?))
+            })
+            .map_err(map_sqlite_error)?;
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.map_err(map_sqlite_error)?);
+        }
+
+        for (node_id, sort_order) in entries {
+            transaction
+                .execute(
+                    "UPDATE root_nodes
+                     SET sort_order = ?1
+                     WHERE node_id = ?2",
+                    params![sort_order - 1, node_id.value()],
+                )
+                .map_err(map_sqlite_error)?;
+        }
     }
     Ok(())
+}
+
+fn ensure_node_is_valid_root(transaction: &Transaction<'_>, node_id: NodeId) -> KernelResult<()> {
+    let node = fetch_node(transaction, node_id)?.ok_or(KernelError::NotFound {
+        entity: "node",
+        id: node_id,
+    })?;
+    let fragments = memoryroam_domain::parse_content(&node.content)
+        .map_err(|error| KernelError::Input(error.to_string()))?;
+    if fragments
+        .iter()
+        .any(|fragment| matches!(fragment, memoryroam_domain::ContentFragment::Link(_)))
+    {
+        return Err(KernelError::Input(String::from(
+            "root content cannot contain links",
+        )));
+    }
+    LookupKey::new(node.content.as_str().to_owned())
+        .map(|_| ())
+        .map_err(|error| KernelError::Input(error.to_string()))
 }
 
 fn register_top_level_nodes(
@@ -2299,6 +2360,7 @@ fn register_top_level_nodes(
     shift_root_sort_orders_from(transaction, start_sort_order, node_ids.len() as i64)?;
 
     for (index, node_id) in node_ids.iter().enumerate() {
+        ensure_node_is_valid_root(transaction, *node_id)?;
         transaction
             .execute(
                 "UPDATE nodes
@@ -2719,6 +2781,43 @@ mod tests {
         let roots = store.list_root_nodes().expect("root nodes should load");
         assert_eq!(roots[0].content.as_str(), "Beta");
         assert_eq!(roots[1].content.as_str(), "Alpha");
+    }
+
+    #[test]
+    fn top_level_first_inserts_before_existing_roots_without_sort_conflicts() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        create_nodes(&mut store, "A", &[], Placement::TopLevelLast).expect("create A");
+        create_nodes(&mut store, "B", &[], Placement::TopLevelLast).expect("create B");
+        create_nodes(&mut store, "C", &[], Placement::TopLevelFirst).expect("create C");
+
+        let roots = store.list_root_nodes().expect("root nodes should load");
+        assert_eq!(roots[0].content.as_str(), "C");
+        assert_eq!(roots[1].content.as_str(), "A");
+        assert_eq!(roots[2].content.as_str(), "B");
+    }
+
+    #[test]
+    fn moving_link_bearing_node_to_top_level_is_rejected() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        let root_id = store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect("root node should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+        let linked_id = create_nodes(
+            &mut store,
+            &format!("Ref {{{{{root_id}}}}}"),
+            &[],
+            Placement::LastChildOf(day_node_id),
+        )
+        .expect("linked note should be created")[0];
+
+        let error = move_node(&mut store, linked_id, Placement::TopLevelLast)
+            .expect_err("invalid root promotion should fail");
+        assert!(matches!(error, KernelError::Input(_)));
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -239,6 +239,37 @@ BEGIN
     SELECT RAISE(ABORT, 'duplicate root lookup key');
 END;
 
+CREATE TRIGGER IF NOT EXISTS child_nodes_reject_reserved_root_lookup_key_on_parent_update
+BEFORE UPDATE OF parent_id ON nodes
+FOR EACH ROW
+WHEN NEW.parent_id IS NOT NULL
+AND EXISTS (
+    SELECT 1
+    FROM root_nodes AS roots
+    JOIN nodes AS root_node
+      ON root_node.id = roots.node_id
+    WHERE root_node.content_lookup_key = NEW.content_lookup_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'reserved root lookup key');
+END;
+
+CREATE TRIGGER IF NOT EXISTS child_nodes_reject_reserved_root_lookup_key_on_update
+BEFORE UPDATE OF content_lookup_key ON nodes
+FOR EACH ROW
+WHEN NEW.parent_id IS NOT NULL
+AND EXISTS (
+    SELECT 1
+    FROM root_nodes AS roots
+    JOIN nodes AS root_node
+      ON root_node.id = roots.node_id
+    WHERE roots.node_id <> OLD.id
+      AND root_node.content_lookup_key = NEW.content_lookup_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'reserved root lookup key');
+END;
+
 CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert
 BEFORE INSERT ON daily_notes
 FOR EACH ROW
@@ -296,6 +327,21 @@ WHEN EXISTS (
 )
 BEGIN
     SELECT RAISE(ABORT, 'daily note date nodes cannot have aliases');
+END;
+
+CREATE TRIGGER IF NOT EXISTS node_aliases_reject_reserved_root_lookup_key
+BEFORE INSERT ON node_aliases
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM root_nodes AS roots
+    JOIN nodes AS root_node
+      ON root_node.id = roots.node_id
+    WHERE roots.node_id <> NEW.node_id
+      AND root_node.content_lookup_key = NEW.alias_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'reserved root lookup key');
 END;
 
 CREATE TRIGGER IF NOT EXISTS node_aliases_reject_daily_note_delete
@@ -2742,21 +2788,30 @@ mod tests {
     fn batch_create_keeps_existing_lookup_candidates_visible() {
         let mut store = store();
         init(&mut store).expect("schema init should succeed");
-        store
-            .create_root_node(&node_record(&store, "Topic"))
-            .expect("root node should be created");
         let day_node_id = store
             .create_daily_note_node("2026-04-11")
             .expect("daily note node should be created");
-
-        let error = create_nodes(
+        let existing_topic_id = create_nodes(
             &mut store,
-            "Topic\nSee {{Topic}}",
+            "Topic",
             &[],
             Placement::LastChildOf(day_node_id),
         )
-        .expect_err("ambiguous lookup should fail");
-        assert!(matches!(error, KernelError::LookupAmbiguous { .. }));
+        .expect("existing note should be created")[0];
+
+        let created_ids = create_nodes(
+            &mut store,
+            "Other\nSee {{Topic}}",
+            &[],
+            Placement::LastChildOf(day_node_id),
+        )
+        .expect("batch create should keep existing lookup candidates visible");
+
+        let dependent_view = read_node(&store, created_ids[1]).expect("read should succeed");
+        assert_eq!(
+            dependent_view.node.rendered_content,
+            format!("See {{{{{existing_topic_id}::Topic}}}}")
+        );
     }
 
     #[test]
@@ -3013,6 +3068,73 @@ mod tests {
             .create_root_node(&node_record(&store, "2026-04-11"))
             .expect("root should ignore daily note date nodes");
         assert_eq!(root_id.value(), 2);
+    }
+
+    #[test]
+    fn child_note_creation_rejects_reserved_root_lookup_keys() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect("root should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+
+        let error = create_nodes(
+            &mut store,
+            "Topic",
+            &[],
+            Placement::LastChildOf(day_node_id),
+        )
+        .expect_err("child note should reject reserved root key");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn child_note_update_rejects_reserved_root_lookup_keys() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect("root should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+        let child_id = create_nodes(
+            &mut store,
+            "Other",
+            &[],
+            Placement::LastChildOf(day_node_id),
+        )
+        .expect("child note should be created")[0];
+
+        let error = update_node(&mut store, child_id, "Topic")
+            .expect_err("child note update should reject reserved root key");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn alias_creation_rejects_reserved_root_lookup_keys() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect("root should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+        let child_id = create_nodes(
+            &mut store,
+            "Other",
+            &[],
+            Placement::LastChildOf(day_node_id),
+        )
+        .expect("child note should be created")[0];
+
+        let error = add_aliases(&mut store, child_id, &[String::from("Topic")])
+            .expect_err("alias should reject reserved root key");
+        assert!(matches!(error, KernelError::Constraint(_)));
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -51,7 +51,8 @@ CREATE TABLE IF NOT EXISTS root_nodes (
     node_id INTEGER PRIMARY KEY
             REFERENCES nodes(id)
             ON DELETE RESTRICT
-            DEFERRABLE INITIALLY DEFERRED
+            DEFERRABLE INITIALLY DEFERRED,
+    sort_order INTEGER NOT NULL UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS daily_notes (
@@ -264,8 +265,12 @@ CREATE TABLE IF NOT EXISTS root_nodes (
     node_id INTEGER PRIMARY KEY
             REFERENCES nodes(id)
             ON DELETE RESTRICT
-            DEFERRABLE INITIALLY DEFERRED
+            DEFERRABLE INITIALLY DEFERRED,
+    sort_order INTEGER NOT NULL UNIQUE
 );
+
+DROP VIEW IF EXISTS v_lookup_candidates;
+DROP VIEW IF EXISTS v_incoming_links;
 
 CREATE TABLE IF NOT EXISTS daily_notes (
     note_date TEXT PRIMARY KEY,
@@ -994,10 +999,18 @@ impl WriteRepository for SqliteStore {
         ensure_schema_initialized(&transaction)?;
 
         let node_id = insert_top_level_node(&transaction, node)?;
+        let next_sort_order = transaction
+            .query_row(
+                "SELECT COALESCE(MAX(sort_order), 0) + 1
+                 FROM root_nodes",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(map_sqlite_error)?;
         transaction
             .execute(
-                "INSERT INTO root_nodes (node_id) VALUES (?1)",
-                params![node_id.value()],
+                "INSERT INTO root_nodes (node_id, sort_order) VALUES (?1, ?2)",
+                params![node_id.value(), next_sort_order],
             )
             .map_err(map_sqlite_error)?;
 
@@ -1456,11 +1469,11 @@ fn migrate_v1_schema(connection: &mut Connection) -> KernelResult<()> {
             .map_err(map_sqlite_error)?;
     }
 
-    for node_id in root_node_ids {
+    for (index, node_id) in root_node_ids.into_iter().enumerate() {
         transaction
             .execute(
-                "INSERT OR IGNORE INTO root_nodes (node_id) VALUES (?1)",
-                params![node_id.value()],
+                "INSERT OR IGNORE INTO root_nodes (node_id, sort_order) VALUES (?1, ?2)",
+                params![node_id.value(), index as i64 + 1],
             )
             .map_err(map_sqlite_error)?;
     }
@@ -1615,15 +1628,15 @@ fn is_root_node_in_handle(handle: &impl SqlHandle, node_id: NodeId) -> KernelRes
 fn list_top_level_nodes_from_handle(handle: &impl SqlHandle) -> KernelResult<Vec<StoredNode>> {
     let mut statement = handle
         .prepare(
-            "SELECT n.id
-             FROM nodes AS n
-             LEFT JOIN root_nodes AS r
-               ON r.node_id = n.id
-             LEFT JOIN daily_notes AS d
-               ON d.node_id = n.id
-             WHERE n.parent_id IS NULL
-               AND (r.node_id IS NOT NULL OR d.node_id IS NOT NULL)
-             ORDER BY n.id",
+            "SELECT node_id
+             FROM (
+                 SELECT r.node_id AS node_id, 0 AS group_order, r.sort_order AS inner_order, '' AS date_order
+                 FROM root_nodes AS r
+                 UNION ALL
+                 SELECT d.node_id AS node_id, 1 AS group_order, 0 AS inner_order, d.note_date AS date_order
+                 FROM daily_notes AS d
+             )
+             ORDER BY group_order, inner_order, date_order",
         )
         .map_err(map_sqlite_error)?;
     let rows = statement
@@ -1646,7 +1659,7 @@ fn list_root_nodes_from_handle(handle: &impl SqlHandle) -> KernelResult<Vec<Stor
         .prepare(
             "SELECT node_id
              FROM root_nodes
-             ORDER BY node_id",
+             ORDER BY sort_order",
         )
         .map_err(map_sqlite_error)?;
     let rows = statement
@@ -2477,11 +2490,22 @@ mod tests {
                 first_child_id  INTEGER REFERENCES nodes(id),
                 last_child_id   INTEGER REFERENCES nodes(id)
             );
+            CREATE TABLE node_aliases (
+                node_id     INTEGER NOT NULL,
+                alias_text  TEXT NOT NULL,
+                alias_key   TEXT NOT NULL
+            );
+            CREATE TABLE node_links (
+                source_node_id  INTEGER NOT NULL,
+                ordinal         INTEGER NOT NULL,
+                target_node_id  INTEGER NOT NULL
+            );
             INSERT INTO nodes(id, content, content_lookup_key, parent_id, first_child_id, last_child_id, prev_sibling_id, next_sibling_id)
             VALUES
-                (1, 'Topic', 'Topic', NULL, NULL, NULL, NULL, 2),
-                (2, 'Other', 'Other', NULL, NULL, NULL, 1, NULL);
-            INSERT INTO tree_root(root_id, first_child_id, last_child_id) VALUES (1, 1, 2);
+                (1, 'A', 'A', NULL, NULL, NULL, 3, 2),
+                (2, 'B', 'B', NULL, NULL, NULL, 1, NULL),
+                (3, 'C', 'C', NULL, NULL, NULL, NULL, 1);
+            INSERT INTO tree_root(root_id, first_child_id, last_child_id) VALUES (1, 3, 2);
             "#,
         )
         .expect("legacy schema should be created");
@@ -2489,11 +2513,23 @@ mod tests {
         init(&mut store).expect("legacy schema should migrate");
 
         let roots = store.list_root_nodes().expect("root nodes should load");
-        assert_eq!(roots.len(), 2);
-        assert_eq!(roots[0].content.as_str(), "Topic");
-        assert_eq!(roots[1].content.as_str(), "Other");
+        assert_eq!(roots.len(), 3);
+        assert_eq!(roots[0].content.as_str(), "C");
+        assert_eq!(roots[1].content.as_str(), "A");
+        assert_eq!(roots[2].content.as_str(), "B");
         assert!(roots.iter().all(|node| node.prev_sibling_id.is_none()));
         assert!(roots.iter().all(|node| node.next_sibling_id.is_none()));
+
+        store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note should be created");
+        let key = LookupKey::new(String::from("2026-04-11")).expect("lookup key should parse");
+        assert!(
+            store
+                .lookup_candidates(&key)
+                .expect("lookup candidates should load")
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -1410,16 +1410,18 @@ fn find_root_node_by_content_from_handle(
     handle: &impl SqlHandle,
     content: &ContentLine,
 ) -> KernelResult<Option<StoredNode>> {
+    let lookup_key =
+        LookupKey::from_content(content).map_err(|error| KernelError::Input(error.to_string()))?;
     handle
         .query_row(
             "SELECT n.id
              FROM root_nodes AS r
              JOIN nodes AS n
                ON n.id = r.node_id
-             WHERE n.content = ?1
+             WHERE n.content_lookup_key = ?1
              ORDER BY n.id
              LIMIT 1",
-            params![content.as_str()],
+            params![lookup_key.as_str()],
             |row| node_id_from_row(row, 0),
         )
         .optional()

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -1743,15 +1743,6 @@ fn validate_placement_target(
     placement: Placement,
     moving_node_id: Option<NodeId>,
 ) -> KernelResult<()> {
-    if matches!(
-        placement,
-        Placement::TopLevelFirst | Placement::TopLevelLast
-    ) {
-        return Err(KernelError::Input(String::from(
-            "top-level placement is not supported",
-        )));
-    }
-
     if let Some(target_id) = placement.target_id() {
         ensure_node_exists_in_db(handle, target_id)?;
         if Some(target_id) == moving_node_id {
@@ -1796,6 +1787,17 @@ fn is_in_subtree(
 }
 
 fn detach_node(transaction: &Transaction<'_>, node: &StoredNode) -> KernelResult<()> {
+    if node.parent_id.is_none() {
+        if !is_root_node_in_handle(transaction, node.id)? {
+            return Err(KernelError::Constraint(format!(
+                "top-level node {} cannot be detached",
+                node.id
+            )));
+        }
+        remove_top_level_nodes(transaction, &[node.id])?;
+        return Ok(());
+    }
+
     let parent_id = node.parent_id.ok_or(KernelError::Constraint(format!(
         "top-level node {} cannot be detached",
         node.id
@@ -1868,15 +1870,28 @@ fn attach_chain(
 ) -> KernelResult<()> {
     match placement {
         Placement::TopLevelFirst | Placement::TopLevelLast => {
-            return Err(KernelError::Input(String::from(
-                "top-level placement is not supported",
-            )));
+            register_top_level_chain(transaction, first_id, last_id, placement)?;
         }
         Placement::Before(target_id) => {
             let target = fetch_node(transaction, target_id)?.ok_or(KernelError::NotFound {
                 entity: "node",
                 id: target_id,
             })?;
+            if target.parent_id.is_none() {
+                if !is_root_node_in_handle(transaction, target_id)? {
+                    return Err(KernelError::Constraint(format!(
+                        "top-level node {target_id} cannot participate in sibling placement"
+                    )));
+                }
+                register_top_level_chain_around_target(
+                    transaction,
+                    first_id,
+                    last_id,
+                    target_id,
+                    true,
+                )?;
+                return Ok(());
+            }
             let target_parent_id = target.parent_id.ok_or(KernelError::Constraint(format!(
                 "top-level node {target_id} cannot participate in sibling placement"
             )))?;
@@ -1933,6 +1948,21 @@ fn attach_chain(
                 entity: "node",
                 id: target_id,
             })?;
+            if target.parent_id.is_none() {
+                if !is_root_node_in_handle(transaction, target_id)? {
+                    return Err(KernelError::Constraint(format!(
+                        "top-level node {target_id} cannot participate in sibling placement"
+                    )));
+                }
+                register_top_level_chain_around_target(
+                    transaction,
+                    first_id,
+                    last_id,
+                    target_id,
+                    false,
+                )?;
+                return Ok(());
+            }
             let target_parent_id = target.parent_id.ok_or(KernelError::Constraint(format!(
                 "top-level node {target_id} cannot participate in sibling placement"
             )))?;
@@ -2134,6 +2164,163 @@ fn set_container_bounds(
         )
         .map_err(map_sqlite_error)?;
     Ok(())
+}
+
+fn chain_node_ids(
+    transaction: &Transaction<'_>,
+    first_id: NodeId,
+    last_id: NodeId,
+) -> KernelResult<Vec<NodeId>> {
+    let mut node_ids = Vec::new();
+    let mut current = Some(first_id);
+    while let Some(node_id) = current {
+        node_ids.push(node_id);
+        if node_id == last_id {
+            break;
+        }
+        current = fetch_node(transaction, node_id)?
+            .ok_or(KernelError::StorageCorruption(format!(
+                "missing node {node_id} while reading chain"
+            )))?
+            .next_sibling_id;
+    }
+    Ok(node_ids)
+}
+
+fn max_root_sort_order(transaction: &Transaction<'_>) -> KernelResult<i64> {
+    transaction
+        .query_row(
+            "SELECT COALESCE(MAX(sort_order), 0)
+             FROM root_nodes",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(map_sqlite_error)
+}
+
+fn root_sort_order(transaction: &Transaction<'_>, node_id: NodeId) -> KernelResult<i64> {
+    transaction
+        .query_row(
+            "SELECT sort_order
+             FROM root_nodes
+             WHERE node_id = ?1",
+            params![node_id.value()],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(map_sqlite_error)
+}
+
+fn shift_root_sort_orders_from(
+    transaction: &Transaction<'_>,
+    start_sort_order: i64,
+    delta: i64,
+) -> KernelResult<()> {
+    if delta == 0 {
+        return Ok(());
+    }
+    transaction
+        .execute(
+            "UPDATE root_nodes
+             SET sort_order = sort_order + ?1
+             WHERE sort_order >= ?2",
+            params![delta, start_sort_order],
+        )
+        .map_err(map_sqlite_error)?;
+    Ok(())
+}
+
+fn remove_top_level_nodes(transaction: &Transaction<'_>, node_ids: &[NodeId]) -> KernelResult<()> {
+    let mut sort_orders = Vec::new();
+    for node_id in node_ids {
+        sort_orders.push(root_sort_order(transaction, *node_id)?);
+        transaction
+            .execute(
+                "DELETE FROM root_nodes WHERE node_id = ?1",
+                params![node_id.value()],
+            )
+            .map_err(map_sqlite_error)?;
+    }
+    sort_orders.sort_unstable();
+    for removed_sort_order in sort_orders {
+        transaction
+            .execute(
+                "UPDATE root_nodes
+                 SET sort_order = sort_order - 1
+                 WHERE sort_order > ?1",
+                params![removed_sort_order],
+            )
+            .map_err(map_sqlite_error)?;
+    }
+    Ok(())
+}
+
+fn register_top_level_nodes(
+    transaction: &Transaction<'_>,
+    node_ids: &[NodeId],
+    start_sort_order: i64,
+) -> KernelResult<()> {
+    if node_ids.is_empty() {
+        return Ok(());
+    }
+
+    shift_root_sort_orders_from(transaction, start_sort_order, node_ids.len() as i64)?;
+
+    for (index, node_id) in node_ids.iter().enumerate() {
+        transaction
+            .execute(
+                "UPDATE nodes
+                 SET parent_id = NULL,
+                     prev_sibling_id = NULL,
+                     next_sibling_id = NULL
+                 WHERE id = ?1",
+                params![node_id.value()],
+            )
+            .map_err(map_sqlite_error)?;
+        transaction
+            .execute(
+                "INSERT INTO root_nodes (node_id, sort_order) VALUES (?1, ?2)",
+                params![node_id.value(), start_sort_order + index as i64],
+            )
+            .map_err(map_sqlite_error)?;
+    }
+
+    Ok(())
+}
+
+fn register_top_level_chain(
+    transaction: &Transaction<'_>,
+    first_id: NodeId,
+    last_id: NodeId,
+    placement: Placement,
+) -> KernelResult<()> {
+    let node_ids = chain_node_ids(transaction, first_id, last_id)?;
+    let start_sort_order = match placement {
+        Placement::TopLevelFirst => 1,
+        Placement::TopLevelLast => max_root_sort_order(transaction)? + 1,
+        _ => {
+            return Err(KernelError::Constraint(String::from(
+                "top-level registration requires a top-level placement",
+            )));
+        }
+    };
+    register_top_level_nodes(transaction, &node_ids, start_sort_order)
+}
+
+fn register_top_level_chain_around_target(
+    transaction: &Transaction<'_>,
+    first_id: NodeId,
+    last_id: NodeId,
+    target_id: NodeId,
+    before_target: bool,
+) -> KernelResult<()> {
+    let node_ids = chain_node_ids(transaction, first_id, last_id)?;
+    let target_sort_order = root_sort_order(transaction, target_id)?;
+    let start_sort_order = if before_target {
+        target_sort_order
+    } else {
+        target_sort_order + 1
+    };
+    register_top_level_nodes(transaction, &node_ids, start_sort_order)
 }
 
 fn find_incoming_link(
@@ -2502,21 +2689,19 @@ mod tests {
         let parent_id = store
             .create_daily_note_node("2026-04-11")
             .expect("first create should succeed");
-        create_nodes(&mut store, "Parent {{1}}", &[], Placement::TopLevelLast)
-            .expect_err("top-level placement should be rejected");
-        create_nodes(
+        let root_id = create_nodes(&mut store, "Parent", &[], Placement::TopLevelLast)
+            .expect("top-level placement should succeed")[0];
+        let child_id = create_nodes(
             &mut store,
-            "Child {{1}}",
+            &format!("Child {{{{{root_id}}}}}"),
             &[],
             Placement::LastChildOf(parent_id),
         )
-        .expect("child create should succeed");
+        .expect("child create should succeed")[0];
 
         assert_eq!(
-            store
-                .node_path(NodeId::new(parent_id.value() + 1).expect("valid id"))
-                .expect("path should load"),
-            "2026-04-11 > Child {{1::>2026-04-11}}"
+            store.node_path(child_id).expect("path should load"),
+            "2026-04-11 > Child {{2::>Parent}}"
         );
     }
 }

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -182,6 +182,18 @@ BEGIN
         FROM daily_notes
         WHERE node_id = NEW.node_id
     );
+
+    SELECT RAISE(ABORT, 'root nodes cannot contain links')
+    WHERE EXISTS (
+        SELECT 1
+        FROM nodes
+        WHERE id = NEW.node_id
+          AND (
+              instr(content, '{{') > 0
+              OR instr(content, '}}') > 0
+              OR instr(content, '::') > 0
+          )
+    );
 END;
 
 CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key
@@ -198,6 +210,43 @@ WHEN EXISTS (
 )
 BEGIN
     SELECT RAISE(ABORT, 'duplicate root lookup key');
+END;
+
+CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key_on_update
+BEFORE UPDATE OF content_lookup_key ON nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM root_nodes
+    WHERE node_id = OLD.id
+)
+AND EXISTS (
+    SELECT 1
+    FROM root_nodes AS r
+    JOIN nodes AS existing
+      ON existing.id = r.node_id
+    WHERE r.node_id <> OLD.id
+      AND existing.content_lookup_key = NEW.content_lookup_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'duplicate root lookup key');
+END;
+
+CREATE TRIGGER IF NOT EXISTS root_nodes_reject_link_syntax_on_update
+BEFORE UPDATE OF content ON nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM root_nodes
+    WHERE node_id = OLD.id
+)
+AND (
+    instr(NEW.content, '{{') > 0
+    OR instr(NEW.content, '}}') > 0
+    OR instr(NEW.content, '::') > 0
+)
+BEGIN
+    SELECT RAISE(ABORT, 'root nodes cannot contain links');
 END;
 
 CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert
@@ -379,6 +428,18 @@ BEGIN
         FROM daily_notes
         WHERE node_id = NEW.node_id
     );
+
+    SELECT RAISE(ABORT, 'root nodes cannot contain links')
+    WHERE EXISTS (
+        SELECT 1
+        FROM nodes
+        WHERE id = NEW.node_id
+          AND (
+              instr(content, '{{') > 0
+              OR instr(content, '}}') > 0
+              OR instr(content, '::') > 0
+          )
+    );
 END;
 
 CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key
@@ -395,6 +456,43 @@ WHEN EXISTS (
 )
 BEGIN
     SELECT RAISE(ABORT, 'duplicate root lookup key');
+END;
+
+CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key_on_update
+BEFORE UPDATE OF content_lookup_key ON nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM root_nodes
+    WHERE node_id = OLD.id
+)
+AND EXISTS (
+    SELECT 1
+    FROM root_nodes AS r
+    JOIN nodes AS existing
+      ON existing.id = r.node_id
+    WHERE r.node_id <> OLD.id
+      AND existing.content_lookup_key = NEW.content_lookup_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'duplicate root lookup key');
+END;
+
+CREATE TRIGGER IF NOT EXISTS root_nodes_reject_link_syntax_on_update
+BEFORE UPDATE OF content ON nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM root_nodes
+    WHERE node_id = OLD.id
+)
+AND (
+    instr(NEW.content, '{{') > 0
+    OR instr(NEW.content, '}}') > 0
+    OR instr(NEW.content, '::') > 0
+)
+BEGIN
+    SELECT RAISE(ABORT, 'root nodes cannot contain links');
 END;
 
 CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -497,9 +497,20 @@ impl ReadRepository for SqliteStore {
 
 impl WriteRepository for SqliteStore {
     fn init_schema(&mut self) -> KernelResult<()> {
-        self.connection
-            .execute_batch(SCHEMA)
-            .map_err(map_sqlite_error)
+        let version = self
+            .connection
+            .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+            .map_err(map_sqlite_error)?;
+        match version {
+            0 => self
+                .connection
+                .execute_batch(SCHEMA)
+                .map_err(map_sqlite_error),
+            2 => Ok(()),
+            other => Err(KernelError::Storage(format!(
+                "unsupported schema version {other}; rebuild the database for schema v2"
+            ))),
+        }
     }
 
     fn create_nodes_from_lines(
@@ -2163,6 +2174,19 @@ mod tests {
                 .expect("daily notes should load")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn init_schema_rejects_legacy_schema_versions() {
+        let mut store = store();
+
+        store
+            .connection
+            .execute_batch("PRAGMA user_version = 1;")
+            .expect("legacy version should be set");
+
+        let error = init(&mut store).expect_err("legacy schema should be rejected");
+        assert!(matches!(error, KernelError::Storage(_)));
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -936,6 +936,48 @@ impl WriteRepository for SqliteStore {
         transaction.commit().map_err(map_sqlite_error)?;
         Ok(node_id)
     }
+
+    fn create_note_in_daily_note(
+        &mut self,
+        note_date: &str,
+        node: &NewNodeRecord,
+    ) -> KernelResult<NodeId> {
+        let transaction = self.connection.transaction().map_err(map_sqlite_error)?;
+        ensure_schema_initialized(&transaction)?;
+
+        let note_node_id = match find_daily_note_from_handle(&transaction, note_date)? {
+            Some(record) => record.node_id,
+            None => {
+                let content = ContentLine::parse(note_date)
+                    .map_err(|error| KernelError::Input(error.to_string()))?;
+                let lookup_key = LookupKey::from_content(&content)
+                    .map_err(|error| KernelError::Input(error.to_string()))?;
+                let note_node = NewNodeRecord {
+                    content,
+                    lookup_key,
+                    outgoing_links: Vec::new(),
+                    aliases: Vec::new(),
+                };
+                let note_node_id = insert_top_level_node(&transaction, &note_node)?;
+                transaction
+                    .execute(
+                        "INSERT INTO daily_notes (note_date, node_id) VALUES (?1, ?2)",
+                        params![note_date, note_node_id.value()],
+                    )
+                    .map_err(map_sqlite_error)?;
+                note_node_id
+            }
+        };
+
+        let node_id = insert_single_node(&transaction, Placement::LastChildOf(note_node_id), node)?;
+        let repository = TransactionRepository {
+            transaction: &transaction,
+        };
+        ensure_no_link_cycle(&repository, node_id)?;
+
+        transaction.commit().map_err(map_sqlite_error)?;
+        Ok(node_id)
+    }
 }
 
 trait SqlHandle {

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -190,12 +190,21 @@ BEFORE INSERT ON root_nodes
 FOR EACH ROW
 WHEN EXISTS (
     SELECT 1
-    FROM root_nodes AS r
-    JOIN nodes AS existing
-      ON existing.id = r.node_id
-    JOIN nodes AS incoming
-      ON incoming.id = NEW.node_id
-    WHERE existing.content_lookup_key = incoming.content_lookup_key
+    FROM nodes AS incoming
+    WHERE incoming.id = NEW.node_id
+      AND (
+        EXISTS (
+        SELECT 1
+        FROM nodes AS existing
+        WHERE existing.id <> NEW.node_id
+          AND existing.content_lookup_key = incoming.content_lookup_key
+    )
+       OR EXISTS (
+        SELECT 1
+        FROM node_aliases AS aliases
+        WHERE aliases.node_id <> NEW.node_id
+          AND aliases.alias_key = incoming.content_lookup_key
+    ))
 )
 BEGIN
     SELECT RAISE(ABORT, 'duplicate root lookup key');
@@ -211,11 +220,14 @@ WHEN EXISTS (
 )
 AND EXISTS (
     SELECT 1
-    FROM root_nodes AS r
-    JOIN nodes AS existing
-      ON existing.id = r.node_id
-    WHERE r.node_id <> OLD.id
+    FROM nodes AS existing
+    WHERE existing.id <> OLD.id
       AND existing.content_lookup_key = NEW.content_lookup_key
+    UNION ALL
+    SELECT 1
+    FROM node_aliases AS aliases
+    WHERE aliases.node_id <> OLD.id
+      AND aliases.alias_key = NEW.content_lookup_key
 )
 BEGIN
     SELECT RAISE(ABORT, 'duplicate root lookup key');
@@ -2944,6 +2956,43 @@ mod tests {
             .create_root_node(&bad_root)
             .expect_err("invalid root should fail");
         assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn create_root_node_rejects_lookup_keys_owned_by_regular_notes() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+        create_nodes(
+            &mut store,
+            "Topic",
+            &[],
+            Placement::LastChildOf(day_node_id),
+        )
+        .expect("note should be created");
+
+        let error = store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect_err("root should reject note-owned lookup key");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn create_root_node_rejects_lookup_keys_owned_by_aliases() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        let owner_id = store
+            .create_root_node(&node_record(&store, "Alias owner"))
+            .expect("root should be created");
+        add_aliases(&mut store, owner_id, &[String::from("Topic")])
+            .expect("alias add should succeed");
+
+        let error = store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect_err("root should reject alias-owned lookup key");
+        assert!(matches!(error, KernelError::Constraint(_)));
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -184,6 +184,22 @@ BEGIN
     );
 END;
 
+CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key
+BEFORE INSERT ON root_nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM root_nodes AS r
+    JOIN nodes AS existing
+      ON existing.id = r.node_id
+    JOIN nodes AS incoming
+      ON incoming.id = NEW.node_id
+    WHERE existing.content_lookup_key = incoming.content_lookup_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'duplicate root lookup key');
+END;
+
 CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert
 BEFORE INSERT ON daily_notes
 FOR EACH ROW
@@ -363,6 +379,22 @@ BEGIN
         FROM daily_notes
         WHERE node_id = NEW.node_id
     );
+END;
+
+CREATE TRIGGER IF NOT EXISTS root_nodes_reject_duplicate_lookup_key
+BEFORE INSERT ON root_nodes
+FOR EACH ROW
+WHEN EXISTS (
+    SELECT 1
+    FROM root_nodes AS r
+    JOIN nodes AS existing
+      ON existing.id = r.node_id
+    JOIN nodes AS incoming
+      ON incoming.id = NEW.node_id
+    WHERE existing.content_lookup_key = incoming.content_lookup_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'duplicate root lookup key');
 END;
 
 CREATE TRIGGER IF NOT EXISTS daily_notes_validate_insert

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -678,9 +678,28 @@ impl WriteRepository for SqliteStore {
 
         let transaction = self.connection.transaction().map_err(map_sqlite_error)?;
         ensure_schema_initialized(&transaction)?;
+        let mut root_update_ids = Vec::new();
 
         for update in updates {
             ensure_node_exists_in_db(&transaction, update.node_id)?;
+            if is_root_node_in_handle(&transaction, update.node_id)? {
+                root_update_ids.push(update.node_id);
+                let temporary_lookup_key = format!("__pending_root_{}__", update.node_id.value());
+                transaction
+                    .execute(
+                        "UPDATE nodes
+                         SET content = ?1, content_lookup_key = ?2
+                         WHERE id = ?3",
+                        params![
+                            update.content.as_str(),
+                            temporary_lookup_key,
+                            update.node_id.value()
+                        ],
+                    )
+                    .map_err(map_sqlite_error)?;
+                refresh_outgoing_links(&transaction, update.node_id, &update.outgoing_links)?;
+                continue;
+            }
             transaction
                 .execute(
                     "UPDATE nodes
@@ -694,6 +713,20 @@ impl WriteRepository for SqliteStore {
                 )
                 .map_err(map_sqlite_error)?;
             refresh_outgoing_links(&transaction, update.node_id, &update.outgoing_links)?;
+        }
+
+        for update in updates {
+            if !root_update_ids.contains(&update.node_id) {
+                continue;
+            }
+            transaction
+                .execute(
+                    "UPDATE nodes
+                     SET content_lookup_key = ?1
+                     WHERE id = ?2",
+                    params![update.lookup_key.as_str(), update.node_id.value()],
+                )
+                .map_err(map_sqlite_error)?;
         }
 
         let repository = TransactionRepository {
@@ -2394,7 +2427,9 @@ mod tests {
         canonicalize_content,
     };
     use memoryroam_read::read_node;
-    use memoryroam_write::{add_aliases, create_nodes, delete_node, init, move_node, update_node};
+    use memoryroam_write::{
+        add_aliases, create_nodes, delete_node, init, move_node, update_node, update_nodes,
+    };
 
     use super::*;
 
@@ -2659,6 +2694,31 @@ mod tests {
             .expect("incoming links should load");
         assert_eq!(incoming.len(), 1);
         assert_eq!(incoming[0].source_node_id, source_id);
+    }
+
+    #[test]
+    fn batch_root_name_swaps_succeed_in_sqlite_storage() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+        let first_id = store
+            .create_root_node(&node_record(&store, "Alpha"))
+            .expect("first root should be created");
+        let second_id = store
+            .create_root_node(&node_record(&store, "Beta"))
+            .expect("second root should be created");
+
+        update_nodes(
+            &mut store,
+            &[
+                (first_id, String::from("Beta")),
+                (second_id, String::from("Alpha")),
+            ],
+        )
+        .expect("root swap should succeed");
+
+        let roots = store.list_root_nodes().expect("root nodes should load");
+        assert_eq!(roots[0].content.as_str(), "Beta");
+        assert_eq!(roots[1].content.as_str(), "Alpha");
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -2328,12 +2328,17 @@ fn remove_top_level_nodes(transaction: &Transaction<'_>, node_ids: &[NodeId]) ->
     Ok(())
 }
 
-fn ensure_node_is_valid_root(transaction: &Transaction<'_>, node_id: NodeId) -> KernelResult<()> {
+fn normalize_node_for_root_promotion(
+    transaction: &Transaction<'_>,
+    node_id: NodeId,
+) -> KernelResult<()> {
     let node = fetch_node(transaction, node_id)?.ok_or(KernelError::NotFound {
         entity: "node",
         id: node_id,
     })?;
-    let fragments = memoryroam_domain::parse_content(&node.content)
+    let normalized_content = ContentLine::parse(node.content.as_str().trim())
+        .map_err(|error| KernelError::Input(error.to_string()))?;
+    let fragments = memoryroam_domain::parse_content(&normalized_content)
         .map_err(|error| KernelError::Input(error.to_string()))?;
     if fragments
         .iter()
@@ -2343,9 +2348,22 @@ fn ensure_node_is_valid_root(transaction: &Transaction<'_>, node_id: NodeId) -> 
             "root content cannot contain links",
         )));
     }
-    LookupKey::new(node.content.as_str().to_owned())
-        .map(|_| ())
-        .map_err(|error| KernelError::Input(error.to_string()))
+    let normalized_lookup_key = LookupKey::new(normalized_content.as_str().to_owned())
+        .map_err(|error| KernelError::Input(error.to_string()))?;
+    transaction
+        .execute(
+            "UPDATE nodes
+             SET content = ?1,
+                 content_lookup_key = ?2
+             WHERE id = ?3",
+            params![
+                normalized_content.as_str(),
+                normalized_lookup_key.as_str(),
+                node_id.value()
+            ],
+        )
+        .map_err(map_sqlite_error)?;
+    Ok(())
 }
 
 fn register_top_level_nodes(
@@ -2360,7 +2378,7 @@ fn register_top_level_nodes(
     shift_root_sort_orders_from(transaction, start_sort_order, node_ids.len() as i64)?;
 
     for (index, node_id) in node_ids.iter().enumerate() {
-        ensure_node_is_valid_root(transaction, *node_id)?;
+        normalize_node_for_root_promotion(transaction, *node_id)?;
         transaction
             .execute(
                 "UPDATE nodes

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -884,6 +884,7 @@ impl WriteRepository for SqliteStore {
     fn create_root_node(&mut self, node: &NewNodeRecord) -> KernelResult<NodeId> {
         let transaction = self.connection.transaction().map_err(map_sqlite_error)?;
         ensure_schema_initialized(&transaction)?;
+        validate_root_content(&node.content)?;
 
         let node_id = insert_top_level_node(&transaction, node)?;
         let next_sort_order = transaction
@@ -2389,16 +2390,7 @@ fn normalize_node_for_root_promotion(
     })?;
     let normalized_content = ContentLine::parse(node.content.as_str().trim())
         .map_err(|error| KernelError::Input(error.to_string()))?;
-    let fragments = memoryroam_domain::parse_content(&normalized_content)
-        .map_err(|error| KernelError::Input(error.to_string()))?;
-    if fragments
-        .iter()
-        .any(|fragment| matches!(fragment, memoryroam_domain::ContentFragment::Link(_)))
-    {
-        return Err(KernelError::Input(String::from(
-            "root content cannot contain links",
-        )));
-    }
+    validate_root_content(&normalized_content)?;
     let normalized_lookup_key = LookupKey::new(normalized_content.as_str().to_owned())
         .map_err(|error| KernelError::Input(error.to_string()))?;
     transaction
@@ -2415,6 +2407,22 @@ fn normalize_node_for_root_promotion(
         )
         .map_err(map_sqlite_error)?;
     Ok(())
+}
+
+fn validate_root_content(content: &ContentLine) -> KernelResult<()> {
+    let fragments = memoryroam_domain::parse_content(content)
+        .map_err(|error| KernelError::Input(error.to_string()))?;
+    if fragments
+        .iter()
+        .any(|fragment| matches!(fragment, memoryroam_domain::ContentFragment::Link(_)))
+    {
+        return Err(KernelError::Input(String::from(
+            "root content cannot contain links",
+        )));
+    }
+    LookupKey::new(content.as_str().to_owned())
+        .map(|_| ())
+        .map_err(|error| KernelError::Input(error.to_string()))
 }
 
 fn register_top_level_nodes(
@@ -2886,6 +2894,23 @@ mod tests {
 
         let error = move_node(&mut store, linked_id, Placement::TopLevelLast)
             .expect_err("invalid root promotion should fail");
+        assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn create_root_node_rejects_link_bearing_content() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+
+        let bad_root = NewNodeRecord {
+            content: ContentLine::parse("Ref {{1}}").expect("content should parse"),
+            lookup_key: LookupKey::new(String::from("bad-root")).expect("lookup key should parse"),
+            outgoing_links: Vec::new(),
+            aliases: Vec::new(),
+        };
+        let error = store
+            .create_root_node(&bad_root)
+            .expect_err("invalid root should fail");
         assert!(matches!(error, KernelError::Input(_)));
     }
 

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -495,7 +495,7 @@ impl ReadRepository for SqliteStore {
                     })?;
                 follow_chain(&self.connection, parent.first_child_id)
             }
-            None => list_root_nodes_from_handle(&self.connection),
+            None => list_top_level_nodes_from_handle(&self.connection),
         }
     }
 
@@ -1072,7 +1072,7 @@ impl ReadRepository for TransactionRepository<'_> {
                     })?;
                 follow_chain(self.transaction, parent.first_child_id)
             }
-            None => list_root_nodes_from_handle(self.transaction),
+            None => list_top_level_nodes_from_handle(self.transaction),
         }
     }
 
@@ -1250,7 +1250,7 @@ impl ReadRepository for BatchCreateRepository<'_> {
                     })?;
                 follow_chain(self.transaction, parent.first_child_id)
             }
-            None => list_root_nodes_from_handle(self.transaction),
+            None => list_top_level_nodes_from_handle(self.transaction),
         }
     }
 
@@ -1610,6 +1610,35 @@ fn is_root_node_in_handle(handle: &impl SqlHandle, node_id: NodeId) -> KernelRes
         )
         .map(|exists| exists == 1)
         .map_err(map_sqlite_error)
+}
+
+fn list_top_level_nodes_from_handle(handle: &impl SqlHandle) -> KernelResult<Vec<StoredNode>> {
+    let mut statement = handle
+        .prepare(
+            "SELECT n.id
+             FROM nodes AS n
+             LEFT JOIN root_nodes AS r
+               ON r.node_id = n.id
+             LEFT JOIN daily_notes AS d
+               ON d.node_id = n.id
+             WHERE n.parent_id IS NULL
+               AND (r.node_id IS NOT NULL OR d.node_id IS NOT NULL)
+             ORDER BY n.id",
+        )
+        .map_err(map_sqlite_error)?;
+    let rows = statement
+        .query_map([], |row| node_id_from_row(row, 0))
+        .map_err(map_sqlite_error)?;
+
+    let mut nodes = Vec::new();
+    for row in rows {
+        let node_id = row.map_err(map_sqlite_error)?;
+        let node = fetch_node(handle, node_id)?.ok_or(KernelError::StorageCorruption(format!(
+            "missing top-level node {node_id}"
+        )))?;
+        nodes.push(node);
+    }
+    Ok(nodes)
 }
 
 fn list_root_nodes_from_handle(handle: &impl SqlHandle) -> KernelResult<Vec<StoredNode>> {
@@ -2404,6 +2433,26 @@ mod tests {
                 .expect("daily notes should load")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn list_children_none_returns_all_top_level_nodes() {
+        let mut store = store();
+        init(&mut store).expect("schema init should succeed");
+
+        let root_id = store
+            .create_root_node(&node_record(&store, "Topic"))
+            .expect("root node should be created");
+        let day_node_id = store
+            .create_daily_note_node("2026-04-11")
+            .expect("daily note node should be created");
+
+        let top_level = store
+            .list_children(None)
+            .expect("top-level list should load");
+        let top_level_ids = top_level.iter().map(|node| node.id).collect::<Vec<_>>();
+
+        assert_eq!(top_level_ids, vec![root_id, day_node_id]);
     }
 
     #[test]

--- a/crates/memoryroam-storage-sqlite/src/lib.rs
+++ b/crates/memoryroam-storage-sqlite/src/lib.rs
@@ -684,7 +684,7 @@ impl WriteRepository for SqliteStore {
             ensure_node_exists_in_db(&transaction, update.node_id)?;
             if is_root_node_in_handle(&transaction, update.node_id)? {
                 root_update_ids.push(update.node_id);
-                let temporary_lookup_key = format!("__pending_root_{}__", update.node_id.value());
+                let temporary_lookup_key = format!(" __pending_root_{}__ ", update.node_id.value());
                 transaction
                     .execute(
                         "UPDATE nodes

--- a/crates/memoryroam-write/README.md
+++ b/crates/memoryroam-write/README.md
@@ -54,6 +54,7 @@ impl WriteRepository for Repo {
     fn remove_alias(&mut self, _node_id: NodeId, _alias: &AliasText) -> KernelResult<()> { todo!() }
     fn create_root_node(&mut self, _node: &NewNodeRecord) -> KernelResult<NodeId> { todo!() }
     fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> { todo!() }
+    fn create_note_in_daily_note(&mut self, _note_date: &str, _node: &NewNodeRecord) -> KernelResult<NodeId> { todo!() }
 }
 
 let mut repo = Repo;

--- a/crates/memoryroam-write/README.md
+++ b/crates/memoryroam-write/README.md
@@ -16,8 +16,9 @@ The storage backend is responsible for the final transaction, structural rewirin
 
 ```rust,no_run
 use memoryroam_domain::{
-    AliasText, ContentLine, IncomingLinkRecord, KernelResult, LookupCandidate, LookupKey,
-    NewNodeRecord, NodeId, Placement, ReadRepository, StoredNode, WriteRepository,
+    AliasText, ContentLine, DailyNoteRecord, IncomingLinkRecord, KernelResult, LookupCandidate,
+    LookupKey, NewNodeRecord, NodeId, NodeUpdateRecord, Placement, ReadRepository, StoredNode,
+    WriteRepository,
 };
 use memoryroam_write::create_nodes;
 use std::collections::{BTreeMap, BTreeSet};
@@ -33,17 +34,26 @@ impl ReadRepository for Repo {
     fn fetch_node_contents(&self, _node_ids: &BTreeSet<NodeId>) -> KernelResult<BTreeMap<NodeId, ContentLine>> { todo!() }
     fn lookup_candidates(&self, _key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> { todo!() }
     fn node_path(&self, _node_id: NodeId) -> KernelResult<String> { todo!() }
+    fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> { todo!() }
+    fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> { todo!() }
+    fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> { todo!() }
+    fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> { todo!() }
+    fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> { todo!() }
+    fn find_root_node_by_content(&self, _content: &ContentLine) -> KernelResult<Option<StoredNode>> { todo!() }
+    fn search_text_matches(&self, _needle: &str) -> KernelResult<Vec<StoredNode>> { todo!() }
 }
 
 impl WriteRepository for Repo {
     fn init_schema(&mut self) -> KernelResult<()> { todo!() }
     fn create_nodes_from_lines(&mut self, _placement: Placement, _lines: &[ContentLine], _aliases: &[AliasText]) -> KernelResult<Vec<NodeId>> { todo!() }
     fn create_nodes(&mut self, _placement: Placement, _nodes: &[NewNodeRecord]) -> KernelResult<Vec<NodeId>> { todo!() }
-    fn update_node_content(&mut self, _node_id: NodeId, _content: &ContentLine, _lookup_key: &LookupKey, _outgoing_links: &[NodeId]) -> KernelResult<()> { todo!() }
+    fn update_node_contents(&mut self, _updates: &[NodeUpdateRecord]) -> KernelResult<()> { todo!() }
     fn move_node(&mut self, _node_id: NodeId, _placement: Placement) -> KernelResult<()> { todo!() }
     fn delete_node(&mut self, _node_id: NodeId, _mode: memoryroam_domain::DeleteMode) -> KernelResult<()> { todo!() }
     fn add_aliases(&mut self, _node_id: NodeId, _aliases: &[AliasText]) -> KernelResult<()> { todo!() }
     fn remove_alias(&mut self, _node_id: NodeId, _alias: &AliasText) -> KernelResult<()> { todo!() }
+    fn create_root_node(&mut self, _node: &NewNodeRecord) -> KernelResult<NodeId> { todo!() }
+    fn create_daily_note_node(&mut self, _note_date: &str) -> KernelResult<NodeId> { todo!() }
 }
 
 let mut repo = Repo;

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -272,6 +272,7 @@ fn validate_root_update<R: ReadRepository>(
 
     ensure_plain_text_root(raw_line)?;
     ensure_safe_root_label_text(raw_line.as_str())?;
+    ensure_referenceable_root_text(raw_line)?;
     let normalized = raw_line.as_str().trim();
     let duplicate_root_exists = repository
         .list_root_nodes()?
@@ -323,6 +324,12 @@ fn ensure_safe_root_label_text(text: &str) -> KernelResult<()> {
 
 fn normalize_root_content(raw_content: &str) -> KernelResult<ContentLine> {
     ContentLine::parse(raw_content.trim()).map_err(|error| KernelError::Input(error.to_string()))
+}
+
+fn ensure_referenceable_root_text(content: &ContentLine) -> KernelResult<()> {
+    LookupKey::new(content.as_str().to_owned())
+        .map(|_| ())
+        .map_err(|error| KernelError::Input(error.to_string()))
 }
 
 struct PendingUpdateRepository<'a, R> {
@@ -946,5 +953,28 @@ mod tests {
         assert_eq!(repository.updated.len(), 2);
         assert_eq!(repository.updated[0].1.as_str(), "Beta");
         assert_eq!(repository.updated[1].1.as_str(), "See {{1::Beta}}");
+    }
+
+    #[test]
+    fn update_node_rejects_numeric_root_content() {
+        let mut repository = FakeRepository::default();
+        let root_id = NodeId::new(1).expect("valid test id");
+        repository.existing.insert(root_id, stored_node(1, "Root"));
+        repository.root_nodes.insert(root_id);
+
+        let error = update_node(&mut repository, root_id, "2026").expect_err("update should fail");
+        assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn update_node_rejects_double_colon_root_content() {
+        let mut repository = FakeRepository::default();
+        let root_id = NodeId::new(1).expect("valid test id");
+        repository.existing.insert(root_id, stored_node(1, "Root"));
+        repository.root_nodes.insert(root_id);
+
+        let error =
+            update_node(&mut repository, root_id, "std::fmt").expect_err("update should fail");
+        assert!(matches!(error, KernelError::Input(_)));
     }
 }

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -55,8 +55,7 @@ pub fn update_node<R: WriteRepository>(
     node_id: NodeId,
     raw_content: &str,
 ) -> KernelResult<()> {
-    let raw_line =
-        ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
+    let raw_line = prepare_updated_content(repository, node_id, raw_content)?;
     validate_root_update(repository, node_id, &raw_line)?;
 
     let CanonicalizedContent {
@@ -107,8 +106,7 @@ pub fn update_nodes<R: WriteRepository>(
             )));
         }
 
-        let content = ContentLine::parse(raw_content.clone())
-            .map_err(|error| KernelError::Input(error.to_string()))?;
+        let content = prepare_updated_content(repository, *node_id, raw_content)?;
         let root_lookup_key = validate_root_update(repository, *node_id, &content)?;
         if let Some(root_lookup_key) = root_lookup_key
             && !seen_root_lookup_keys.insert(root_lookup_key)
@@ -265,15 +263,30 @@ fn validate_root_update<R: WriteRepository>(
 
     ensure_plain_text_root(raw_line)?;
     ensure_safe_root_label_text(raw_line.as_str())?;
-    if let Some(existing_root) = repository.find_root_node_by_content(raw_line)?
-        && existing_root.id != node_id
-    {
+    let normalized = raw_line.as_str().trim();
+    let duplicate_root_exists = repository
+        .list_root_nodes()?
+        .into_iter()
+        .any(|root| root.id != node_id && root.content.as_str().trim() == normalized);
+    if duplicate_root_exists {
         return Err(KernelError::Constraint(String::from(
             "root lookup keys must stay unique",
         )));
     }
 
-    Ok(Some(raw_line.as_str().trim().to_owned()))
+    Ok(Some(normalized.to_owned()))
+}
+
+fn prepare_updated_content<R: WriteRepository>(
+    repository: &R,
+    node_id: NodeId,
+    raw_content: &str,
+) -> KernelResult<ContentLine> {
+    if repository.is_root_node(node_id)? {
+        return normalize_root_content(raw_content);
+    }
+
+    ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))
 }
 
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
@@ -297,6 +310,10 @@ fn ensure_safe_root_label_text(text: &str) -> KernelResult<()> {
         )));
     }
     Ok(())
+}
+
+fn normalize_root_content(raw_content: &str) -> KernelResult<ContentLine> {
+    ContentLine::parse(raw_content.trim()).map_err(|error| KernelError::Input(error.to_string()))
 }
 
 #[cfg(test)]
@@ -395,7 +412,11 @@ mod tests {
         }
 
         fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
-            Ok(Vec::new())
+            Ok(self
+                .root_nodes
+                .iter()
+                .filter_map(|node_id| self.existing.get(node_id).cloned())
+                .collect())
         }
 
         fn find_root_node_by_content(
@@ -683,6 +704,18 @@ mod tests {
             .insert(second_id, stored_node(2, "Other"));
         repository.root_nodes.insert(first_id);
         repository.root_nodes.insert(second_id);
+        assert!(
+            repository
+                .is_root_node(second_id)
+                .expect("root state should load")
+        );
+        assert_eq!(
+            repository
+                .list_root_nodes()
+                .expect("root nodes should load")
+                .len(),
+            2
+        );
 
         let error =
             update_node(&mut repository, second_id, "Topic").expect_err("update should fail");
@@ -702,6 +735,11 @@ mod tests {
         repository
             .aliases
             .insert(String::from("Target"), vec![target_id]);
+        assert!(
+            repository
+                .is_root_node(root_id)
+                .expect("root state should load")
+        );
 
         let error = update_node(&mut repository, root_id, "Ref {{Target}}")
             .expect_err("update should fail");

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeSet, VecDeque};
 
 use memoryroam_domain::{
     AliasText, CanonicalizedContent, ContentLine, DeleteMode, KernelError, KernelResult, LookupKey,
-    NodeId, Placement, WriteRepository, canonicalize_content,
+    NodeId, NodeUpdateRecord, Placement, WriteRepository, canonicalize_content,
 };
 
 /// Initializes the target repository schema.
@@ -54,6 +54,12 @@ pub fn update_node<R: WriteRepository>(
     node_id: NodeId,
     raw_content: &str,
 ) -> KernelResult<()> {
+    if repository.is_daily_note_node(node_id)? {
+        return Err(KernelError::Constraint(String::from(
+            "daily note date nodes are immutable",
+        )));
+    }
+
     let content =
         ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
     let CanonicalizedContent {
@@ -70,7 +76,64 @@ pub fn update_node<R: WriteRepository>(
 
     ensure_no_link_cycle(repository, node_id, &outgoing_links)?;
 
-    repository.update_node_content(node_id, &content, &lookup_key, &outgoing_links)
+    repository.update_node_contents(&[NodeUpdateRecord {
+        node_id,
+        content,
+        lookup_key,
+        outgoing_links,
+    }])
+}
+
+/// Validates and canonicalizes multiple node updates before writing them atomically.
+pub fn update_nodes<R: WriteRepository>(
+    repository: &mut R,
+    updates: &[(NodeId, String)],
+) -> KernelResult<()> {
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    let mut canonical_updates = Vec::with_capacity(updates.len());
+    let mut seen_node_ids = BTreeSet::new();
+
+    for (node_id, raw_content) in updates {
+        if !seen_node_ids.insert(*node_id) {
+            return Err(KernelError::Input(format!(
+                "node {node_id} was updated more than once"
+            )));
+        }
+
+        if repository.is_daily_note_node(*node_id)? {
+            return Err(KernelError::Constraint(String::from(
+                "daily note date nodes are immutable",
+            )));
+        }
+
+        let content = ContentLine::parse(raw_content.clone())
+            .map_err(|error| KernelError::Input(error.to_string()))?;
+        let CanonicalizedContent {
+            content,
+            lookup_key,
+            outgoing_links,
+        } = canonicalize_content(repository, &content)?;
+
+        if outgoing_links.contains(node_id) {
+            return Err(KernelError::Constraint(format!(
+                "node {node_id} cannot link to itself"
+            )));
+        }
+
+        ensure_no_link_cycle(repository, *node_id, &outgoing_links)?;
+
+        canonical_updates.push(NodeUpdateRecord {
+            node_id: *node_id,
+            content,
+            lookup_key,
+            outgoing_links,
+        });
+    }
+
+    repository.update_node_contents(&canonical_updates)
 }
 
 fn ensure_no_link_cycle<R: WriteRepository>(
@@ -106,6 +169,12 @@ pub fn move_node<R: WriteRepository>(
     node_id: NodeId,
     placement: Placement,
 ) -> KernelResult<()> {
+    if repository.is_daily_note_node(node_id)? {
+        return Err(KernelError::Constraint(String::from(
+            "daily note date nodes are immutable",
+        )));
+    }
+
     repository.move_node(node_id, placement)
 }
 
@@ -115,6 +184,12 @@ pub fn delete_node<R: WriteRepository>(
     node_id: NodeId,
     mode: DeleteMode,
 ) -> KernelResult<()> {
+    if repository.is_daily_note_node(node_id)? {
+        return Err(KernelError::Constraint(String::from(
+            "daily note date nodes are immutable",
+        )));
+    }
+
     repository.delete_node(node_id, mode)
 }
 
@@ -124,6 +199,12 @@ pub fn add_aliases<R: WriteRepository>(
     node_id: NodeId,
     raw_aliases: &[String],
 ) -> KernelResult<()> {
+    if repository.is_daily_note_node(node_id)? {
+        return Err(KernelError::Constraint(String::from(
+            "daily note date nodes cannot have aliases",
+        )));
+    }
+
     if raw_aliases.is_empty() {
         return Err(KernelError::Input(String::from(
             "alias add requires at least one alias",
@@ -145,6 +226,12 @@ pub fn remove_alias<R: WriteRepository>(
     node_id: NodeId,
     raw_alias: &str,
 ) -> KernelResult<()> {
+    if repository.is_daily_note_node(node_id)? {
+        return Err(KernelError::Constraint(String::from(
+            "daily note date nodes cannot have aliases",
+        )));
+    }
+
     let alias = AliasText::new(raw_alias.to_owned())
         .map_err(|error| KernelError::Input(error.to_string()))?;
 
@@ -161,7 +248,9 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use memoryroam_domain::{LookupCandidate, NewNodeRecord, ReadRepository, StoredNode};
+    use memoryroam_domain::{
+        DailyNoteRecord, LookupCandidate, NewNodeRecord, ReadRepository, StoredNode,
+    };
 
     #[derive(Default)]
     struct FakeRepository {
@@ -230,6 +319,37 @@ mod tests {
 
         fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
             Ok(format!("path:{node_id}"))
+        }
+
+        fn find_daily_note(&self, _note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+            Ok(None)
+        }
+
+        fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+            Ok(Vec::new())
+        }
+
+        fn is_daily_note_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> {
+            Ok(false)
+        }
+
+        fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
+        }
+
+        fn find_root_node_by_content(
+            &self,
+            _content: &ContentLine,
+        ) -> KernelResult<Option<StoredNode>> {
+            Ok(None)
+        }
+
+        fn search_text_matches(&self, _needle: &str) -> KernelResult<Vec<StoredNode>> {
+            Ok(Vec::new())
         }
     }
 
@@ -311,20 +431,20 @@ mod tests {
             Ok(created_ids)
         }
 
-        fn update_node_content(
+        fn update_node_contents(
             &mut self,
-            node_id: NodeId,
-            content: &ContentLine,
-            lookup_key: &LookupKey,
-            outgoing_links: &[NodeId],
+            updates: &[memoryroam_domain::NodeUpdateRecord],
         ) -> KernelResult<()> {
-            self.outgoing.insert(node_id, outgoing_links.to_vec());
-            self.updated.push((
-                node_id,
-                content.clone(),
-                lookup_key.clone(),
-                outgoing_links.to_vec(),
-            ));
+            for update in updates {
+                self.outgoing
+                    .insert(update.node_id, update.outgoing_links.clone());
+                self.updated.push((
+                    update.node_id,
+                    update.content.clone(),
+                    update.lookup_key.clone(),
+                    update.outgoing_links.clone(),
+                ));
+            }
             Ok(())
         }
 
@@ -344,6 +464,26 @@ mod tests {
 
         fn remove_alias(&mut self, _node_id: NodeId, _alias: &AliasText) -> KernelResult<()> {
             Ok(())
+        }
+
+        fn create_root_node(&mut self, node: &NewNodeRecord) -> KernelResult<NodeId> {
+            self.create_nodes(Placement::TopLevelLast, std::slice::from_ref(node))
+                .map(|mut ids| ids.remove(0))
+        }
+
+        fn create_daily_note_node(&mut self, note_date: &str) -> KernelResult<NodeId> {
+            let content = ContentLine::parse(note_date)
+                .map_err(|error| KernelError::Input(error.to_string()))?;
+            let lookup_key = LookupKey::from_content(&content)
+                .map_err(|error| KernelError::Input(error.to_string()))?;
+            let node = NewNodeRecord {
+                content,
+                lookup_key,
+                outgoing_links: Vec::new(),
+                aliases: Vec::new(),
+            };
+            self.create_nodes(Placement::TopLevelLast, &[node])
+                .map(|mut ids| ids.remove(0))
         }
     }
 

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -264,6 +264,7 @@ fn validate_root_update<R: WriteRepository>(
     }
 
     ensure_plain_text_root(raw_line)?;
+    ensure_safe_root_label_text(raw_line.as_str())?;
     if let Some(existing_root) = repository.find_root_node_by_content(raw_line)?
         && existing_root.id != node_id
     {
@@ -284,6 +285,15 @@ fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
     {
         return Err(KernelError::Input(String::from(
             "root content cannot contain links",
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_safe_root_label_text(text: &str) -> KernelResult<()> {
+    if text.contains("{{") || text.contains("}}") {
+        return Err(KernelError::Input(String::from(
+            "root text cannot contain raw link delimiters",
         )));
     }
     Ok(())

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -57,21 +57,7 @@ pub fn update_node<R: WriteRepository>(
 ) -> KernelResult<()> {
     let raw_line =
         ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
-    if repository.is_daily_note_node(node_id)? {
-        return Err(KernelError::Constraint(String::from(
-            "daily note date nodes are immutable",
-        )));
-    }
-    if repository.is_root_node(node_id)? {
-        ensure_plain_text_root(&raw_line)?;
-        if let Some(existing_root) = repository.find_root_node_by_content(&raw_line)?
-            && existing_root.id != node_id
-        {
-            return Err(KernelError::Constraint(String::from(
-                "root lookup keys must stay unique",
-            )));
-        }
-    }
+    validate_root_update(repository, node_id, &raw_line)?;
 
     let CanonicalizedContent {
         content,
@@ -106,6 +92,7 @@ pub fn update_nodes<R: WriteRepository>(
 
     let mut canonical_updates = Vec::with_capacity(updates.len());
     let mut seen_node_ids = BTreeSet::new();
+    let mut seen_root_lookup_keys = BTreeSet::new();
 
     for (node_id, raw_content) in updates {
         if !seen_node_ids.insert(*node_id) {
@@ -122,6 +109,14 @@ pub fn update_nodes<R: WriteRepository>(
 
         let content = ContentLine::parse(raw_content.clone())
             .map_err(|error| KernelError::Input(error.to_string()))?;
+        let root_lookup_key = validate_root_update(repository, *node_id, &content)?;
+        if let Some(root_lookup_key) = root_lookup_key
+            && !seen_root_lookup_keys.insert(root_lookup_key)
+        {
+            return Err(KernelError::Constraint(String::from(
+                "root lookup keys must stay unique",
+            )));
+        }
         let CanonicalizedContent {
             content,
             lookup_key,
@@ -252,6 +247,32 @@ pub fn remove_alias<R: WriteRepository>(
 /// Builds a normalized lookup key from raw user input.
 pub fn create_lookup_key(raw_value: &str) -> KernelResult<LookupKey> {
     LookupKey::new(raw_value.to_owned()).map_err(|error| KernelError::Input(error.to_string()))
+}
+
+fn validate_root_update<R: WriteRepository>(
+    repository: &R,
+    node_id: NodeId,
+    raw_line: &ContentLine,
+) -> KernelResult<Option<String>> {
+    if repository.is_daily_note_node(node_id)? {
+        return Err(KernelError::Constraint(String::from(
+            "daily note date nodes are immutable",
+        )));
+    }
+    if !repository.is_root_node(node_id)? {
+        return Ok(None);
+    }
+
+    ensure_plain_text_root(raw_line)?;
+    if let Some(existing_root) = repository.find_root_node_by_content(raw_line)?
+        && existing_root.id != node_id
+    {
+        return Err(KernelError::Constraint(String::from(
+            "root lookup keys must stay unique",
+        )));
+    }
+
+    Ok(Some(raw_line.as_str().trim().to_owned()))
 }
 
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
@@ -674,6 +695,28 @@ mod tests {
 
         let error = update_node(&mut repository, root_id, "Ref {{Target}}")
             .expect_err("update should fail");
+        assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn update_nodes_rejects_link_bearing_root_content() {
+        let mut repository = FakeRepository::default();
+        let root_id = NodeId::new(1).expect("valid test id");
+        let target_id = NodeId::new(2).expect("valid test id");
+        repository.existing.insert(root_id, stored_node(1, "Root"));
+        repository
+            .existing
+            .insert(target_id, stored_node(2, "Target"));
+        repository.root_nodes.insert(root_id);
+        repository
+            .aliases
+            .insert(String::from("Target"), vec![target_id]);
+
+        let error = update_nodes(
+            &mut repository,
+            &[(root_id, String::from("Ref {{Target}}"))],
+        )
+        .expect_err("batch update should fail");
         assert!(matches!(error, KernelError::Input(_)));
     }
 }

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -448,11 +448,19 @@ impl<R: WriteRepository> ReadRepository for PendingUpdateRepository<'_, R> {
             .base
             .lookup_candidates(key)?
             .into_iter()
-            .filter(|candidate| !self.pending_updates.contains_key(&candidate.node_id))
+            .map(|mut candidate| {
+                if let Some(update) = self.pending_updates.get(&candidate.node_id) {
+                    candidate.content = update.content.clone();
+                }
+                candidate
+            })
             .collect::<Vec<_>>();
 
         for (node_id, update) in self.pending_updates {
-            if update.lookup_key.as_str() == key.as_str() {
+            let already_present = candidates
+                .iter()
+                .any(|candidate| candidate.node_id == *node_id);
+            if !already_present && update.lookup_key.as_str() == key.as_str() {
                 candidates.push(memoryroam_domain::LookupCandidate {
                     node_id: *node_id,
                     content: update.content.clone(),
@@ -1018,6 +1026,35 @@ mod tests {
         assert_eq!(repository.updated.len(), 2);
         assert_eq!(repository.updated[0].1.as_str(), "Beta");
         assert_eq!(repository.updated[1].1.as_str(), "See {{1::Beta}}");
+    }
+
+    #[test]
+    fn update_nodes_keep_existing_aliases_visible_for_pending_nodes() {
+        let mut repository = FakeRepository::default();
+        let aliased_id = NodeId::new(1).expect("valid test id");
+        let dependent_id = NodeId::new(2).expect("valid test id");
+        repository
+            .existing
+            .insert(aliased_id, stored_node(1, "Old"));
+        repository
+            .existing
+            .insert(dependent_id, stored_node(2, "See {{topic}}"));
+        repository
+            .aliases
+            .insert(String::from("topic"), vec![aliased_id]);
+
+        update_nodes(
+            &mut repository,
+            &[
+                (aliased_id, String::from("New")),
+                (dependent_id, String::from("See {{topic}}")),
+            ],
+        )
+        .expect("batch update should preserve alias lookups");
+
+        assert_eq!(repository.updated.len(), 2);
+        assert_eq!(repository.updated[0].1.as_str(), "New");
+        assert_eq!(repository.updated[1].1.as_str(), "See {{1::topic}}");
     }
 
     #[test]

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -25,9 +25,21 @@ pub fn create_nodes<R: WriteRepository>(
 ) -> KernelResult<Vec<NodeId>> {
     let lines = raw_input
         .lines()
-        .map(ContentLine::parse)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| KernelError::Input(error.to_string()))?;
+        .map(|line| {
+            if matches!(
+                placement,
+                Placement::TopLevelFirst | Placement::TopLevelLast
+            ) {
+                let content = normalize_root_content(line)?;
+                ensure_plain_text_root(&content)?;
+                ensure_safe_root_label_text(content.as_str())?;
+                ensure_referenceable_root_text(&content)?;
+                Ok(content)
+            } else {
+                ContentLine::parse(line).map_err(|error| KernelError::Input(error.to_string()))
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     if lines.is_empty() {
         return Err(KernelError::Input(String::from(
@@ -787,6 +799,21 @@ mod tests {
     }
 
     #[test]
+    fn create_nodes_rejects_link_bearing_top_level_roots() {
+        let mut repository = FakeRepository::default();
+
+        let error = create_nodes(
+            &mut repository,
+            "Ref {{Topic}}",
+            &[],
+            Placement::TopLevelLast,
+        )
+        .expect_err("top-level root should reject link-bearing text");
+
+        assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
     fn update_node_canonicalizes_lookup_tokens_before_persisting() {
         let mut repository = FakeRepository::default();
         let target = stored_node(7, "Topic");
@@ -810,12 +837,16 @@ mod tests {
     #[test]
     fn create_nodes_allows_later_lines_to_reference_earlier_lines() {
         let mut repository = FakeRepository::default();
+        let parent_id = NodeId::new(10).expect("valid test id");
+        repository
+            .existing
+            .insert(parent_id, stored_node(10, "Parent"));
 
         let created_ids = create_nodes(
             &mut repository,
             "Topic\nSee {{Topic}}",
             &[],
-            Placement::TopLevelLast,
+            Placement::LastChildOf(parent_id),
         )
         .expect("multiline create should allow later lines to reference earlier ones");
 

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -111,6 +111,11 @@ pub fn update_nodes<R: WriteRepository>(
                 "node {node_id} was updated more than once"
             )));
         }
+        if repository.is_daily_note_node(*node_id)? {
+            return Err(KernelError::Constraint(String::from(
+                "daily note date nodes are immutable",
+            )));
+        }
 
         let validation_repository = PendingUpdateRepository {
             base: repository,
@@ -357,7 +362,7 @@ fn prepare_updated_content<R: ReadRepository>(
 
 fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
     let fragments =
-        parse_content(content).map_err(|error| KernelError::Storage(error.to_string()))?;
+        parse_content(content).map_err(|error| KernelError::Input(error.to_string()))?;
     if fragments
         .iter()
         .any(|fragment| matches!(fragment, ContentFragment::Link(_)))
@@ -1093,6 +1098,145 @@ mod tests {
         assert_eq!(repository.updated.len(), 2);
         assert_eq!(repository.updated[0].1.as_str(), "New");
         assert_eq!(repository.updated[1].1.as_str(), "See {{1::topic}}");
+    }
+
+    #[test]
+    fn update_nodes_reject_daily_note_nodes() {
+        let mut repository = FakeRepository::default();
+        let day_id = NodeId::new(1).expect("valid test id");
+        repository
+            .existing
+            .insert(day_id, stored_node(1, "2026-04-12"));
+
+        struct DailyNoteRepo(FakeRepository, NodeId);
+
+        impl ReadRepository for DailyNoteRepo {
+            fn get_node(&self, node_id: NodeId) -> KernelResult<Option<StoredNode>> {
+                self.0.get_node(node_id)
+            }
+            fn list_children(&self, parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
+                self.0.list_children(parent_id)
+            }
+            fn list_outgoing_links(&self, node_id: NodeId) -> KernelResult<Vec<NodeId>> {
+                self.0.list_outgoing_links(node_id)
+            }
+            fn list_incoming_links(
+                &self,
+                node_id: NodeId,
+            ) -> KernelResult<Vec<memoryroam_domain::IncomingLinkRecord>> {
+                self.0.list_incoming_links(node_id)
+            }
+            fn list_aliases(&self, node_id: NodeId) -> KernelResult<Vec<AliasText>> {
+                self.0.list_aliases(node_id)
+            }
+            fn fetch_node_contents(
+                &self,
+                node_ids: &BTreeSet<NodeId>,
+            ) -> KernelResult<BTreeMap<NodeId, ContentLine>> {
+                self.0.fetch_node_contents(node_ids)
+            }
+            fn lookup_candidates(&self, key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
+                self.0.lookup_candidates(key)
+            }
+            fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
+                self.0.node_path(node_id)
+            }
+            fn find_daily_note(&self, note_date: &str) -> KernelResult<Option<DailyNoteRecord>> {
+                self.0.find_daily_note(note_date)
+            }
+            fn list_daily_notes(&self) -> KernelResult<Vec<DailyNoteRecord>> {
+                self.0.list_daily_notes()
+            }
+            fn is_daily_note_node(&self, node_id: NodeId) -> KernelResult<bool> {
+                Ok(node_id == self.1)
+            }
+            fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+                self.0.is_root_node(node_id)
+            }
+            fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+                self.0.list_root_nodes()
+            }
+            fn find_root_node_by_content(
+                &self,
+                content: &ContentLine,
+            ) -> KernelResult<Option<StoredNode>> {
+                self.0.find_root_node_by_content(content)
+            }
+            fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+                self.0.search_text_matches(needle)
+            }
+        }
+
+        impl WriteRepository for DailyNoteRepo {
+            fn init_schema(&mut self) -> KernelResult<()> {
+                self.0.init_schema()
+            }
+            fn create_nodes_from_lines(
+                &mut self,
+                placement: Placement,
+                lines: &[ContentLine],
+                aliases: &[AliasText],
+            ) -> KernelResult<Vec<NodeId>> {
+                self.0.create_nodes_from_lines(placement, lines, aliases)
+            }
+            fn create_nodes(
+                &mut self,
+                placement: Placement,
+                nodes: &[NewNodeRecord],
+            ) -> KernelResult<Vec<NodeId>> {
+                self.0.create_nodes(placement, nodes)
+            }
+            fn update_node_contents(
+                &mut self,
+                updates: &[memoryroam_domain::NodeUpdateRecord],
+            ) -> KernelResult<()> {
+                self.0.update_node_contents(updates)
+            }
+            fn move_node(&mut self, node_id: NodeId, placement: Placement) -> KernelResult<()> {
+                self.0.move_node(node_id, placement)
+            }
+            fn delete_node(&mut self, node_id: NodeId, mode: DeleteMode) -> KernelResult<()> {
+                self.0.delete_node(node_id, mode)
+            }
+            fn add_aliases(&mut self, node_id: NodeId, aliases: &[AliasText]) -> KernelResult<()> {
+                self.0.add_aliases(node_id, aliases)
+            }
+            fn remove_alias(&mut self, node_id: NodeId, alias: &AliasText) -> KernelResult<()> {
+                self.0.remove_alias(node_id, alias)
+            }
+            fn create_root_node(&mut self, node: &NewNodeRecord) -> KernelResult<NodeId> {
+                self.0.create_root_node(node)
+            }
+            fn create_daily_note_node(&mut self, note_date: &str) -> KernelResult<NodeId> {
+                self.0.create_daily_note_node(note_date)
+            }
+            fn create_note_in_daily_note(
+                &mut self,
+                note_date: &str,
+                node: &NewNodeRecord,
+            ) -> KernelResult<NodeId> {
+                self.0.create_note_in_daily_note(note_date, node)
+            }
+        }
+
+        let mut repository = DailyNoteRepo(repository, day_id);
+        let error = update_nodes(&mut repository, &[(day_id, String::from("2026-04-13"))])
+            .expect_err("daily note update should fail");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn create_nodes_report_malformed_top_level_root_text_as_input_error() {
+        let mut repository = FakeRepository::default();
+
+        let error = create_nodes(
+            &mut repository,
+            "Broken {{oops",
+            &[],
+            Placement::TopLevelLast,
+        )
+        .expect_err("malformed root text should fail");
+        assert!(matches!(error, KernelError::Input(_)));
     }
 
     #[test]

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -3,12 +3,12 @@
 #![warn(rustdoc::private_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use memoryroam_domain::{
     AliasText, CanonicalizedContent, ContentFragment, ContentLine, DeleteMode, KernelError,
-    KernelResult, LookupKey, NodeId, NodeUpdateRecord, Placement, WriteRepository,
-    canonicalize_content, parse_content,
+    KernelResult, LookupKey, NodeId, NodeUpdateRecord, Placement, ReadRepository, StoredNode,
+    WriteRepository, canonicalize_content, parse_content,
 };
 
 /// Initializes the target repository schema.
@@ -90,6 +90,7 @@ pub fn update_nodes<R: WriteRepository>(
     }
 
     let mut canonical_updates = Vec::with_capacity(updates.len());
+    let mut pending_updates = BTreeMap::new();
     let mut seen_node_ids = BTreeSet::new();
     let mut seen_root_lookup_keys = BTreeSet::new();
 
@@ -100,14 +101,13 @@ pub fn update_nodes<R: WriteRepository>(
             )));
         }
 
-        if repository.is_daily_note_node(*node_id)? {
-            return Err(KernelError::Constraint(String::from(
-                "daily note date nodes are immutable",
-            )));
-        }
+        let validation_repository = PendingUpdateRepository {
+            base: repository,
+            pending_updates: &pending_updates,
+        };
 
-        let content = prepare_updated_content(repository, *node_id, raw_content)?;
-        let root_lookup_key = validate_root_update(repository, *node_id, &content)?;
+        let content = prepare_updated_content(&validation_repository, *node_id, raw_content)?;
+        let root_lookup_key = validate_root_update(&validation_repository, *node_id, &content)?;
         if let Some(root_lookup_key) = root_lookup_key
             && !seen_root_lookup_keys.insert(root_lookup_key)
         {
@@ -119,7 +119,7 @@ pub fn update_nodes<R: WriteRepository>(
             content,
             lookup_key,
             outgoing_links,
-        } = canonicalize_content(repository, &content)?;
+        } = canonicalize_content(&validation_repository, &content)?;
 
         if outgoing_links.contains(node_id) {
             return Err(KernelError::Constraint(format!(
@@ -127,20 +127,29 @@ pub fn update_nodes<R: WriteRepository>(
             )));
         }
 
-        ensure_no_link_cycle(repository, *node_id, &outgoing_links)?;
-
-        canonical_updates.push(NodeUpdateRecord {
+        let update = NodeUpdateRecord {
             node_id: *node_id,
             content,
             lookup_key,
             outgoing_links,
-        });
+        };
+
+        let mut trial_updates = pending_updates.clone();
+        trial_updates.insert(*node_id, update.clone());
+        let cycle_repository = PendingUpdateRepository {
+            base: repository,
+            pending_updates: &trial_updates,
+        };
+        ensure_no_link_cycle(&cycle_repository, *node_id, &update.outgoing_links)?;
+
+        pending_updates = trial_updates;
+        canonical_updates.push(update);
     }
 
     repository.update_node_contents(&canonical_updates)
 }
 
-fn ensure_no_link_cycle<R: WriteRepository>(
+fn ensure_no_link_cycle<R: ReadRepository>(
     repository: &R,
     node_id: NodeId,
     outgoing_links: &[NodeId],
@@ -247,7 +256,7 @@ pub fn create_lookup_key(raw_value: &str) -> KernelResult<LookupKey> {
     LookupKey::new(raw_value.to_owned()).map_err(|error| KernelError::Input(error.to_string()))
 }
 
-fn validate_root_update<R: WriteRepository>(
+fn validate_root_update<R: ReadRepository>(
     repository: &R,
     node_id: NodeId,
     raw_line: &ContentLine,
@@ -277,7 +286,7 @@ fn validate_root_update<R: WriteRepository>(
     Ok(Some(normalized.to_owned()))
 }
 
-fn prepare_updated_content<R: WriteRepository>(
+fn prepare_updated_content<R: ReadRepository>(
     repository: &R,
     node_id: NodeId,
     raw_content: &str,
@@ -314,6 +323,144 @@ fn ensure_safe_root_label_text(text: &str) -> KernelResult<()> {
 
 fn normalize_root_content(raw_content: &str) -> KernelResult<ContentLine> {
     ContentLine::parse(raw_content.trim()).map_err(|error| KernelError::Input(error.to_string()))
+}
+
+struct PendingUpdateRepository<'a, R> {
+    base: &'a R,
+    pending_updates: &'a BTreeMap<NodeId, NodeUpdateRecord>,
+}
+
+impl<R: WriteRepository> ReadRepository for PendingUpdateRepository<'_, R> {
+    fn get_node(&self, node_id: NodeId) -> KernelResult<Option<StoredNode>> {
+        let Some(mut node) = self.base.get_node(node_id)? else {
+            return Ok(None);
+        };
+        if let Some(update) = self.pending_updates.get(&node_id) {
+            node.content = update.content.clone();
+        }
+        Ok(Some(node))
+    }
+
+    fn list_children(&self, parent_id: Option<NodeId>) -> KernelResult<Vec<StoredNode>> {
+        self.base
+            .list_children(parent_id)?
+            .into_iter()
+            .map(|node| {
+                self.get_node(node.id)?
+                    .ok_or(KernelError::StorageCorruption(format!(
+                        "missing pending child node {}",
+                        node.id
+                    )))
+            })
+            .collect()
+    }
+
+    fn list_outgoing_links(&self, node_id: NodeId) -> KernelResult<Vec<NodeId>> {
+        if let Some(update) = self.pending_updates.get(&node_id) {
+            return Ok(update.outgoing_links.clone());
+        }
+
+        self.base.list_outgoing_links(node_id)
+    }
+
+    fn list_incoming_links(
+        &self,
+        node_id: NodeId,
+    ) -> KernelResult<Vec<memoryroam_domain::IncomingLinkRecord>> {
+        self.base.list_incoming_links(node_id)
+    }
+
+    fn list_aliases(&self, node_id: NodeId) -> KernelResult<Vec<AliasText>> {
+        self.base.list_aliases(node_id)
+    }
+
+    fn fetch_node_contents(
+        &self,
+        node_ids: &BTreeSet<NodeId>,
+    ) -> KernelResult<BTreeMap<NodeId, ContentLine>> {
+        let mut contents = self.base.fetch_node_contents(node_ids)?;
+        for node_id in node_ids {
+            if let Some(update) = self.pending_updates.get(node_id) {
+                contents.insert(*node_id, update.content.clone());
+            }
+        }
+        Ok(contents)
+    }
+
+    fn lookup_candidates(
+        &self,
+        key: &LookupKey,
+    ) -> KernelResult<Vec<memoryroam_domain::LookupCandidate>> {
+        let mut candidates = self
+            .base
+            .lookup_candidates(key)?
+            .into_iter()
+            .filter(|candidate| !self.pending_updates.contains_key(&candidate.node_id))
+            .collect::<Vec<_>>();
+
+        for (node_id, update) in self.pending_updates {
+            if update.lookup_key.as_str() == key.as_str() {
+                candidates.push(memoryroam_domain::LookupCandidate {
+                    node_id: *node_id,
+                    content: update.content.clone(),
+                    path: self.node_path(*node_id)?,
+                });
+            }
+        }
+
+        candidates.sort_by_key(|candidate| candidate.node_id);
+        Ok(candidates)
+    }
+
+    fn node_path(&self, node_id: NodeId) -> KernelResult<String> {
+        self.base.node_path(node_id)
+    }
+
+    fn find_daily_note(
+        &self,
+        note_date: &str,
+    ) -> KernelResult<Option<memoryroam_domain::DailyNoteRecord>> {
+        self.base.find_daily_note(note_date)
+    }
+
+    fn list_daily_notes(&self) -> KernelResult<Vec<memoryroam_domain::DailyNoteRecord>> {
+        self.base.list_daily_notes()
+    }
+
+    fn is_daily_note_node(&self, node_id: NodeId) -> KernelResult<bool> {
+        self.base.is_daily_note_node(node_id)
+    }
+
+    fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+        self.base.is_root_node(node_id)
+    }
+
+    fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
+        self.base
+            .list_root_nodes()?
+            .into_iter()
+            .map(|node| {
+                self.get_node(node.id)?
+                    .ok_or(KernelError::StorageCorruption(format!(
+                        "missing pending root node {}",
+                        node.id
+                    )))
+            })
+            .collect()
+    }
+
+    fn find_root_node_by_content(&self, content: &ContentLine) -> KernelResult<Option<StoredNode>> {
+        let normalized = content.as_str().trim();
+        let matching_root = self
+            .list_root_nodes()?
+            .into_iter()
+            .find(|root| root.content.as_str().trim() == normalized);
+        Ok(matching_root)
+    }
+
+    fn search_text_matches(&self, needle: &str) -> KernelResult<Vec<StoredNode>> {
+        self.base.search_text_matches(needle)
+    }
 }
 
 #[cfg(test)]
@@ -375,7 +522,14 @@ mod tests {
         }
 
         fn lookup_candidates(&self, key: &LookupKey) -> KernelResult<Vec<LookupCandidate>> {
-            let ids = self.aliases.get(key.as_str()).cloned().unwrap_or_default();
+            let mut ids = self.aliases.get(key.as_str()).cloned().unwrap_or_default();
+            for (node_id, node) in &self.existing {
+                if node.content.as_str().trim() == key.as_str() {
+                    ids.push(*node_id);
+                }
+            }
+            ids.sort();
+            ids.dedup();
             Ok(ids
                 .into_iter()
                 .map(|node_id| LookupCandidate {
@@ -766,5 +920,31 @@ mod tests {
         )
         .expect_err("batch update should fail");
         assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn update_nodes_can_reference_earlier_renames_in_the_same_batch() {
+        let mut repository = FakeRepository::default();
+        let renamed_id = NodeId::new(1).expect("valid test id");
+        let dependent_id = NodeId::new(2).expect("valid test id");
+        repository
+            .existing
+            .insert(renamed_id, stored_node(1, "Alpha"));
+        repository
+            .existing
+            .insert(dependent_id, stored_node(2, "See {{Alpha}}"));
+
+        update_nodes(
+            &mut repository,
+            &[
+                (renamed_id, String::from("Beta")),
+                (dependent_id, String::from("See {{Beta}}")),
+            ],
+        )
+        .expect("batch update should succeed");
+
+        assert_eq!(repository.updated.len(), 2);
+        assert_eq!(repository.updated[0].1.as_str(), "Beta");
+        assert_eq!(repository.updated[1].1.as_str(), "See {{1::Beta}}");
     }
 }

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -6,8 +6,9 @@
 use std::collections::{BTreeSet, VecDeque};
 
 use memoryroam_domain::{
-    AliasText, CanonicalizedContent, ContentLine, DeleteMode, KernelError, KernelResult, LookupKey,
-    NodeId, NodeUpdateRecord, Placement, WriteRepository, canonicalize_content,
+    AliasText, CanonicalizedContent, ContentFragment, ContentLine, DeleteMode, KernelError,
+    KernelResult, LookupKey, NodeId, NodeUpdateRecord, Placement, WriteRepository,
+    canonicalize_content, parse_content,
 };
 
 /// Initializes the target repository schema.
@@ -54,19 +55,29 @@ pub fn update_node<R: WriteRepository>(
     node_id: NodeId,
     raw_content: &str,
 ) -> KernelResult<()> {
+    let raw_line =
+        ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
     if repository.is_daily_note_node(node_id)? {
         return Err(KernelError::Constraint(String::from(
             "daily note date nodes are immutable",
         )));
     }
+    if repository.is_root_node(node_id)? {
+        ensure_plain_text_root(&raw_line)?;
+        if let Some(existing_root) = repository.find_root_node_by_content(&raw_line)?
+            && existing_root.id != node_id
+        {
+            return Err(KernelError::Constraint(String::from(
+                "root lookup keys must stay unique",
+            )));
+        }
+    }
 
-    let content =
-        ContentLine::parse(raw_content).map_err(|error| KernelError::Input(error.to_string()))?;
     let CanonicalizedContent {
         content,
         lookup_key,
         outgoing_links,
-    } = canonicalize_content(repository, &content)?;
+    } = canonicalize_content(repository, &raw_line)?;
 
     if outgoing_links.contains(&node_id) {
         return Err(KernelError::Constraint(format!(
@@ -243,6 +254,20 @@ pub fn create_lookup_key(raw_value: &str) -> KernelResult<LookupKey> {
     LookupKey::new(raw_value.to_owned()).map_err(|error| KernelError::Input(error.to_string()))
 }
 
+fn ensure_plain_text_root(content: &ContentLine) -> KernelResult<()> {
+    let fragments =
+        parse_content(content).map_err(|error| KernelError::Storage(error.to_string()))?;
+    if fragments
+        .iter()
+        .any(|fragment| matches!(fragment, ContentFragment::Link(_)))
+    {
+        return Err(KernelError::Input(String::from(
+            "root content cannot contain links",
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -257,6 +282,7 @@ mod tests {
         existing: BTreeMap<NodeId, StoredNode>,
         aliases: BTreeMap<String, Vec<NodeId>>,
         outgoing: BTreeMap<NodeId, Vec<NodeId>>,
+        root_nodes: BTreeSet<NodeId>,
         created: Vec<NewNodeRecord>,
         updated: Vec<(NodeId, ContentLine, LookupKey, Vec<NodeId>)>,
         next_created_id: i64,
@@ -333,8 +359,8 @@ mod tests {
             Ok(false)
         }
 
-        fn is_root_node(&self, _node_id: NodeId) -> KernelResult<bool> {
-            Ok(false)
+        fn is_root_node(&self, node_id: NodeId) -> KernelResult<bool> {
+            Ok(self.root_nodes.contains(&node_id))
         }
 
         fn list_root_nodes(&self) -> KernelResult<Vec<StoredNode>> {
@@ -343,9 +369,15 @@ mod tests {
 
         fn find_root_node_by_content(
             &self,
-            _content: &ContentLine,
+            content: &ContentLine,
         ) -> KernelResult<Option<StoredNode>> {
-            Ok(None)
+            let normalized = content.as_str().trim();
+            Ok(self.root_nodes.iter().find_map(|node_id| {
+                self.existing
+                    .get(node_id)
+                    .filter(|node| node.content.as_str().trim() == normalized)
+                    .cloned()
+            }))
         }
 
         fn search_text_matches(&self, _needle: &str) -> KernelResult<Vec<StoredNode>> {
@@ -467,8 +499,11 @@ mod tests {
         }
 
         fn create_root_node(&mut self, node: &NewNodeRecord) -> KernelResult<NodeId> {
-            self.create_nodes(Placement::TopLevelLast, std::slice::from_ref(node))
-                .map(|mut ids| ids.remove(0))
+            let node_id = self
+                .create_nodes(Placement::TopLevelLast, std::slice::from_ref(node))
+                .map(|mut ids| ids.remove(0))?;
+            self.root_nodes.insert(node_id);
+            Ok(node_id)
         }
 
         fn create_daily_note_node(&mut self, note_date: &str) -> KernelResult<NodeId> {
@@ -602,5 +637,43 @@ mod tests {
             .expect_err("indirect cycles should be rejected");
 
         assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn update_node_rejects_duplicate_root_lookup_keys() {
+        let mut repository = FakeRepository::default();
+        let first_id = NodeId::new(1).expect("valid test id");
+        let second_id = NodeId::new(2).expect("valid test id");
+        repository
+            .existing
+            .insert(first_id, stored_node(1, "Topic"));
+        repository
+            .existing
+            .insert(second_id, stored_node(2, "Other"));
+        repository.root_nodes.insert(first_id);
+        repository.root_nodes.insert(second_id);
+
+        let error =
+            update_node(&mut repository, second_id, "Topic").expect_err("update should fail");
+        assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn update_node_rejects_link_bearing_root_content() {
+        let mut repository = FakeRepository::default();
+        let root_id = NodeId::new(1).expect("valid test id");
+        let target_id = NodeId::new(2).expect("valid test id");
+        repository.existing.insert(root_id, stored_node(1, "Root"));
+        repository
+            .existing
+            .insert(target_id, stored_node(2, "Target"));
+        repository.root_nodes.insert(root_id);
+        repository
+            .aliases
+            .insert(String::from("Target"), vec![target_id]);
+
+        let error = update_node(&mut repository, root_id, "Ref {{Target}}")
+            .expect_err("update should fail");
+        assert!(matches!(error, KernelError::Input(_)));
     }
 }

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -203,9 +203,16 @@ pub fn move_node<R: WriteRepository>(
             Placement::TopLevelFirst | Placement::TopLevelLast
         )
     {
-        return Err(KernelError::Constraint(String::from(
-            "root nodes must remain at the top level",
-        )));
+        let target_id = placement.target_id();
+        let target_is_root = match target_id {
+            Some(target_id) => repository.is_root_node(target_id)?,
+            None => false,
+        };
+        if !target_is_root {
+            return Err(KernelError::Constraint(String::from(
+                "root nodes must remain at the top level",
+            )));
+        }
     }
 
     repository.move_node(node_id, placement)
@@ -1142,5 +1149,23 @@ mod tests {
         let error = move_node(&mut repository, root_id, Placement::LastChildOf(parent_id))
             .expect_err("root move should fail");
         assert!(matches!(error, KernelError::Constraint(_)));
+    }
+
+    #[test]
+    fn move_node_allows_reordering_roots_around_other_roots() {
+        let mut repository = FakeRepository::default();
+        let first_id = NodeId::new(1).expect("valid test id");
+        let second_id = NodeId::new(2).expect("valid test id");
+        repository
+            .existing
+            .insert(first_id, stored_node(1, "First"));
+        repository
+            .existing
+            .insert(second_id, stored_node(2, "Second"));
+        repository.root_nodes.insert(first_id);
+        repository.root_nodes.insert(second_id);
+
+        move_node(&mut repository, first_id, Placement::After(second_id))
+            .expect("root reorder should succeed");
     }
 }

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -205,7 +205,10 @@ pub fn move_node<R: WriteRepository>(
     {
         let target_id = placement.target_id();
         let target_is_root = match target_id {
-            Some(target_id) => repository.is_root_node(target_id)?,
+            Some(target_id) => {
+                repository.is_root_node(target_id)?
+                    && matches!(placement, Placement::Before(_) | Placement::After(_))
+            }
             None => false,
         };
         if !target_is_root {
@@ -451,32 +454,27 @@ impl<R: WriteRepository> ReadRepository for PendingUpdateRepository<'_, R> {
         &self,
         key: &LookupKey,
     ) -> KernelResult<Vec<memoryroam_domain::LookupCandidate>> {
-        let mut candidates = self
-            .base
-            .lookup_candidates(key)?
-            .into_iter()
-            .filter_map(|mut candidate| {
-                let Some(update) = self.pending_updates.get(&candidate.node_id) else {
-                    return Some(Ok(candidate));
-                };
+        let mut candidates = Vec::new();
+        for mut candidate in self.base.lookup_candidates(key)? {
+            let Some(update) = self.pending_updates.get(&candidate.node_id) else {
+                candidates.push(candidate);
+                continue;
+            };
 
-                let alias_matches = self
-                    .base
-                    .list_aliases(candidate.node_id)
-                    .ok()
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|alias| LookupKey::from_alias(&alias).ok())
-                    .any(|alias_key| alias_key.as_str() == key.as_str());
-                let updated_content_matches = update.lookup_key.as_str() == key.as_str();
-                if !alias_matches && !updated_content_matches {
-                    return None;
-                }
+            let alias_matches = self
+                .base
+                .list_aliases(candidate.node_id)?
+                .into_iter()
+                .filter_map(|alias| LookupKey::from_alias(&alias).ok())
+                .any(|alias_key| alias_key.as_str() == key.as_str());
+            let updated_content_matches = update.lookup_key.as_str() == key.as_str();
+            if !alias_matches && !updated_content_matches {
+                continue;
+            }
 
-                candidate.content = update.content.clone();
-                Some(Ok(candidate))
-            })
-            .collect::<KernelResult<Vec<_>>>()?;
+            candidate.content = update.content.clone();
+            candidates.push(candidate);
+        }
 
         for (node_id, update) in self.pending_updates {
             let already_present = candidates
@@ -813,6 +811,19 @@ mod tests {
             };
             self.create_nodes(Placement::TopLevelLast, &[node])
                 .map(|mut ids| ids.remove(0))
+        }
+
+        fn create_note_in_daily_note(
+            &mut self,
+            note_date: &str,
+            node: &NewNodeRecord,
+        ) -> KernelResult<NodeId> {
+            let note_node_id = self.create_daily_note_node(note_date)?;
+            self.create_nodes(
+                Placement::LastChildOf(note_node_id),
+                std::slice::from_ref(node),
+            )
+            .map(|mut ids| ids.remove(0))
         }
     }
 

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -448,13 +448,28 @@ impl<R: WriteRepository> ReadRepository for PendingUpdateRepository<'_, R> {
             .base
             .lookup_candidates(key)?
             .into_iter()
-            .map(|mut candidate| {
-                if let Some(update) = self.pending_updates.get(&candidate.node_id) {
-                    candidate.content = update.content.clone();
+            .filter_map(|mut candidate| {
+                let Some(update) = self.pending_updates.get(&candidate.node_id) else {
+                    return Some(Ok(candidate));
+                };
+
+                let alias_matches = self
+                    .base
+                    .list_aliases(candidate.node_id)
+                    .ok()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|alias| LookupKey::from_alias(&alias).ok())
+                    .any(|alias_key| alias_key.as_str() == key.as_str());
+                let updated_content_matches = update.lookup_key.as_str() == key.as_str();
+                if !alias_matches && !updated_content_matches {
+                    return None;
                 }
-                candidate
+
+                candidate.content = update.content.clone();
+                Some(Ok(candidate))
             })
-            .collect::<Vec<_>>();
+            .collect::<KernelResult<Vec<_>>>()?;
 
         for (node_id, update) in self.pending_updates {
             let already_present = candidates
@@ -565,7 +580,12 @@ mod tests {
         }
 
         fn list_aliases(&self, _node_id: NodeId) -> KernelResult<Vec<AliasText>> {
-            Ok(Vec::new())
+            Ok(self
+                .aliases
+                .iter()
+                .filter(|(_, node_ids)| node_ids.contains(&_node_id))
+                .map(|(alias, _)| AliasText::new(alias.clone()).expect("alias should parse"))
+                .collect())
         }
 
         fn fetch_node_contents(

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -92,7 +92,6 @@ pub fn update_nodes<R: WriteRepository>(
     let mut canonical_updates = Vec::with_capacity(updates.len());
     let mut pending_updates = BTreeMap::new();
     let mut seen_node_ids = BTreeSet::new();
-    let mut seen_root_lookup_keys = BTreeSet::new();
 
     for (node_id, raw_content) in updates {
         if !seen_node_ids.insert(*node_id) {
@@ -107,14 +106,7 @@ pub fn update_nodes<R: WriteRepository>(
         };
 
         let content = prepare_updated_content(&validation_repository, *node_id, raw_content)?;
-        let root_lookup_key = validate_root_update(&validation_repository, *node_id, &content)?;
-        if let Some(root_lookup_key) = root_lookup_key
-            && !seen_root_lookup_keys.insert(root_lookup_key)
-        {
-            return Err(KernelError::Constraint(String::from(
-                "root lookup keys must stay unique",
-            )));
-        }
+        validate_root_shape(&validation_repository, *node_id, &content)?;
         let CanonicalizedContent {
             content,
             lookup_key,
@@ -145,6 +137,12 @@ pub fn update_nodes<R: WriteRepository>(
         pending_updates = trial_updates;
         canonical_updates.push(update);
     }
+
+    let final_repository = PendingUpdateRepository {
+        base: repository,
+        pending_updates: &pending_updates,
+    };
+    ensure_unique_root_lookup_keys(&final_repository)?;
 
     repository.update_node_contents(&canonical_updates)
 }
@@ -270,9 +268,7 @@ fn validate_root_update<R: ReadRepository>(
         return Ok(None);
     }
 
-    ensure_plain_text_root(raw_line)?;
-    ensure_safe_root_label_text(raw_line.as_str())?;
-    ensure_referenceable_root_text(raw_line)?;
+    validate_root_shape(repository, node_id, raw_line)?;
     let normalized = raw_line.as_str().trim();
     let duplicate_root_exists = repository
         .list_root_nodes()?
@@ -285,6 +281,34 @@ fn validate_root_update<R: ReadRepository>(
     }
 
     Ok(Some(normalized.to_owned()))
+}
+
+fn validate_root_shape<R: ReadRepository>(
+    repository: &R,
+    node_id: NodeId,
+    raw_line: &ContentLine,
+) -> KernelResult<()> {
+    if !repository.is_root_node(node_id)? {
+        return Ok(());
+    }
+
+    ensure_plain_text_root(raw_line)?;
+    ensure_safe_root_label_text(raw_line.as_str())?;
+    ensure_referenceable_root_text(raw_line)?;
+    Ok(())
+}
+
+fn ensure_unique_root_lookup_keys<R: ReadRepository>(repository: &R) -> KernelResult<()> {
+    let mut seen = BTreeSet::new();
+    for root in repository.list_root_nodes()? {
+        let normalized = root.content.as_str().trim().to_owned();
+        if !seen.insert(normalized) {
+            return Err(KernelError::Constraint(String::from(
+                "root lookup keys must stay unique",
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn prepare_updated_content<R: ReadRepository>(
@@ -953,6 +977,34 @@ mod tests {
         assert_eq!(repository.updated.len(), 2);
         assert_eq!(repository.updated[0].1.as_str(), "Beta");
         assert_eq!(repository.updated[1].1.as_str(), "See {{1::Beta}}");
+    }
+
+    #[test]
+    fn update_nodes_allow_root_name_swaps() {
+        let mut repository = FakeRepository::default();
+        let first_id = NodeId::new(1).expect("valid test id");
+        let second_id = NodeId::new(2).expect("valid test id");
+        repository
+            .existing
+            .insert(first_id, stored_node(1, "Alpha"));
+        repository
+            .existing
+            .insert(second_id, stored_node(2, "Beta"));
+        repository.root_nodes.insert(first_id);
+        repository.root_nodes.insert(second_id);
+
+        update_nodes(
+            &mut repository,
+            &[
+                (first_id, String::from("Beta")),
+                (second_id, String::from("Alpha")),
+            ],
+        )
+        .expect("root swap should succeed");
+
+        assert_eq!(repository.updated.len(), 2);
+        assert_eq!(repository.updated[0].1.as_str(), "Beta");
+        assert_eq!(repository.updated[1].1.as_str(), "Alpha");
     }
 
     #[test]

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -197,6 +197,16 @@ pub fn move_node<R: WriteRepository>(
             "daily note date nodes are immutable",
         )));
     }
+    if repository.is_root_node(node_id)?
+        && !matches!(
+            placement,
+            Placement::TopLevelFirst | Placement::TopLevelLast
+        )
+    {
+        return Err(KernelError::Constraint(String::from(
+            "root nodes must remain at the top level",
+        )));
+    }
 
     repository.move_node(node_id, placement)
 }
@@ -1059,5 +1069,21 @@ mod tests {
         let error =
             update_node(&mut repository, root_id, "std::fmt").expect_err("update should fail");
         assert!(matches!(error, KernelError::Input(_)));
+    }
+
+    #[test]
+    fn move_node_rejects_moving_roots_out_of_top_level() {
+        let mut repository = FakeRepository::default();
+        let root_id = NodeId::new(1).expect("valid test id");
+        let parent_id = NodeId::new(2).expect("valid test id");
+        repository.existing.insert(root_id, stored_node(1, "Root"));
+        repository
+            .existing
+            .insert(parent_id, stored_node(2, "Parent"));
+        repository.root_nodes.insert(root_id);
+
+        let error = move_node(&mut repository, root_id, Placement::LastChildOf(parent_id))
+            .expect_err("root move should fail");
+        assert!(matches!(error, KernelError::Constraint(_)));
     }
 }

--- a/crates/memoryroam-write/src/lib.rs
+++ b/crates/memoryroam-write/src/lib.rs
@@ -143,15 +143,7 @@ pub fn update_nodes<R: WriteRepository>(
             outgoing_links,
         };
 
-        let mut trial_updates = pending_updates.clone();
-        trial_updates.insert(*node_id, update.clone());
-        let cycle_repository = PendingUpdateRepository {
-            base: repository,
-            pending_updates: &trial_updates,
-        };
-        ensure_no_link_cycle(&cycle_repository, *node_id, &update.outgoing_links)?;
-
-        pending_updates = trial_updates;
+        pending_updates.insert(*node_id, update.clone());
         canonical_updates.push(update);
     }
 
@@ -159,6 +151,9 @@ pub fn update_nodes<R: WriteRepository>(
         base: repository,
         pending_updates: &pending_updates,
     };
+    for update in &canonical_updates {
+        ensure_no_link_cycle(&final_repository, update.node_id, &update.outgoing_links)?;
+    }
     ensure_unique_root_lookup_keys(&final_repository)?;
 
     repository.update_node_contents(&canonical_updates)
@@ -1098,6 +1093,41 @@ mod tests {
         assert_eq!(repository.updated.len(), 2);
         assert_eq!(repository.updated[0].1.as_str(), "New");
         assert_eq!(repository.updated[1].1.as_str(), "See {{1::topic}}");
+    }
+
+    #[test]
+    fn update_nodes_accept_atomic_cycle_breaking_rewrites() {
+        let mut repository = FakeRepository::default();
+        let first_id = NodeId::new(1).expect("valid test id");
+        let second_id = NodeId::new(2).expect("valid test id");
+        repository
+            .existing
+            .insert(first_id, stored_node(1, "Alpha"));
+        repository
+            .existing
+            .insert(second_id, stored_node(2, "Beta"));
+        repository
+            .aliases
+            .insert(String::from("Alpha"), vec![first_id]);
+        repository
+            .aliases
+            .insert(String::from("Beta"), vec![second_id]);
+        repository.outgoing.insert(second_id, vec![first_id]);
+
+        update_nodes(
+            &mut repository,
+            &[
+                (first_id, String::from("See {{Beta}}")),
+                (second_id, String::from("Beta revised")),
+            ],
+        )
+        .expect("final batch graph should be acyclic");
+
+        assert_eq!(repository.updated.len(), 2);
+        assert_eq!(repository.updated[0].1.as_str(), "See {{2::Beta}}");
+        assert_eq!(repository.updated[1].1.as_str(), "Beta revised");
+        assert_eq!(repository.updated[0].3, vec![second_id]);
+        assert!(repository.updated[1].3.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- redesign the CLI around `note`, `day`, `read`, `root create`, and `root apply`
- add a unified application layer for user-facing workflows and move formatter logic out of business paths
- replace the old top-level tree model with parallel `root` and `daily_notes` top-level sets
- tighten root invariants across create, apply, single update, and batch update paths
- document that this unreleased redesign does not provide migration or backward compatibility for older database files

## Why
The previous CLI still exposed storage-oriented operations and required users to think in terms of low-level placement and IDs. This change shifts the default interaction model to note-taking workflows while keeping invariants coherent across the new root and daily-note behaviors.

## Validation
- `cargo fmt --all -- --check`
- `cargo xtask agents-md-index check`
- `cargo test --workspace`
- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `codex-review-final main`
